### PR TITLE
Fix Task and CVE links in changelogs/markdown

### DIFF
--- a/solus_sc/changelog.py
+++ b/solus_sc/changelog.py
@@ -19,11 +19,11 @@ from . import PACKAGE_ICON_NORMAL
 from . import PACKAGE_ICON_SECURITY
 
 # Helpful for determing CVE matches.
-CVE_HIT = re.compile(r"(CVE\-[0-9]+\-[0-9]+)")
-CVE_URI = "https://cve.mitre.org/cgi-bin/cvename.cgi?name={}"
+CVE_HIT = re.compile(r" (CVE\-[0-9]+\-[0-9]+)")
+CVE_URI = "https://cve.mitre.org/cgi-bin/cvename.cgi?name="
 
 # All TNNNN hits are Maniphest Tasks
-BUG_HIT = re.compile(r"T(\d+)")
+BUG_HIT = re.compile(r" T(\d+)")
 BUG_URI = "https://dev.getsol.us"
 
 # I know, it's evil. From:
@@ -65,8 +65,8 @@ class ScChangelogEntry(Gtk.EventBox):
             r = MARKUP_URI_HIT.sub(r'<a href="\2">\1</a>', r)
             r = MARKUP_CODE_HIT.sub(r'<tt>\1</tt>', r)
             r = MARKUP_BOLD_HIT.sub(r'<b>\1</b>', r)
-            r = CVE_HIT.sub(r'<a href="\1">\1</a>', r)
-            r = BUG_HIT.sub(r'<a href="{}/T\1">T\1</a>'.format(BUG_URI), r)
+            r = CVE_HIT.sub(r' <a href="{}\1">\1</a>'.format(CVE_URI), r)
+            r = BUG_HIT.sub(r' <a href="{}/T\1">T\1</a>'.format(BUG_URI), r)
 
             # Check if this is a bullet point
             if (r.startswith("- ") or r.startswith("* ")) and len(r) > 2:

--- a/xng/util/markdown.py
+++ b/xng/util/markdown.py
@@ -14,11 +14,11 @@
 import re
 
 # Helpful for determing CVE matches.
-CVE_HIT = re.compile(r"(CVE\-[0-9]+\-[0-9]+)")
+CVE_HIT = re.compile(r" (CVE\-[0-9]+\-[0-9]+)")
 CVE_URI = "https://cve.mitre.org/cgi-bin/cvename.cgi?name={}"
 
 # All TNNNN hits are Maniphest Tasks
-BUG_HIT = re.compile(r"T(\d+)")
+BUG_HIT = re.compile(r" T(\d+)")
 BUG_URI = "https://dev.getsol.us"
 
 # I know, it's evil. From:
@@ -104,8 +104,8 @@ class SpecialMarkdownParser:
                 r = r.split(id)[1].strip()
                 break
 
-            r = CVE_HIT.sub(r'<a href="\1">\1</a>', r)
-            r = BUG_HIT.sub(r'<a href="{}/T\1">T\1</a>'.format(BUG_URI), r)
+            r = CVE_HIT.sub(r' <a href="{}\1">\1</a>'.format(CVE_URI), r)
+            r = BUG_HIT.sub(r' <a href="{}/T\1">T\1</a>'.format(BUG_URI), r)
 
             # Check if this is a bullet point
             if (r.startswith("- ") or r.startswith("* ")) and len(r) > 2:


### PR DESCRIPTION
If tasks or CVEs are linked to directly in a phabricator diff, solus-sc tried to create a link inside of a link. Fix this by only checking for matches after a space. Also fix CVE links, which probably didn't work for quite some time because the base URI wasn't added.

Example of recent borked changelog:
https://i.imgur.com/uv8zMGz.png

with fix:
https://i.imgur.com/AxuCTkj.png