### PR TITLE
Remove papirus-adapta-icon-theme

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -380,5 +380,6 @@
 	<Package>yum</Package>
 	<Package>yum-utils</Package>
 	<Package>godot</Package>
+	<Package>papirus-adapta-icon-theme</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -544,5 +544,8 @@
 
 	<!-- Splitted into godot-classic and godot-mono //-->
 	<Package>godot</Package>
+	
+	<!-- Removed from upstream due to Adapta not being maintained anymore //-->
+	<Package>papirus-adapta-icon-theme</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Removes papirus-adapta-icon-theme since it isn't part of the upstream anymore due to Adapta not being developed anymore. See [D5250](https://dev.getsol.us/D5250) for more info on the removal...