### PR TITLE
repo_data: deprecate python-faulthandler

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -407,41 +407,54 @@
 	<Package>empathy</Package>
 	<Package>galculator</Package>
 	<Package>gitg</Package>
+	<Package>gitg-devel</Package>
 	<Package>gnome-code-assistance</Package>
 	<Package>gnome-code-assistance-devel</Package>
 	<Package>gnome-contacts</Package>
 	<Package>gnome-dictionary</Package>
 	<Package>gnome-games</Package>
+	<Package>gnome-games-devel</Package>
 	<Package>gnome-python</Package>
 	<Package>gnome-python-devel</Package>
 	<Package>gnome-python-docs</Package>
 	<Package>gnome-themes-standard</Package>
 	<Package>gnome-themes-standard-32bit</Package>
 	<Package>gnome-todo</Package>
+	<Package>gnome-todo-devel</Package>
+	<Package>gnome-todo-docs</Package>
 	<Package>gtef</Package>
+	<Package>gtef-devel</Package>
+	<Package>gtef-docs</Package>
 	<Package>hardcode-tray</Package>
 	<Package>latexila</Package>
+	<Package>latexila-docs</Package>
 	<Package>libdmapsharing</Package>
 	<Package>libdmapsharing-devel</Package>
+	<Package>libdmapsharing-docs</Package>
 	<Package>libwebkit3-gtk</Package>
 	<Package>libwebkit3-gtk-devel</Package>
 	<Package>libwebkit3-gtk-docs</Package>
 	<Package>pwned-checker</Package>
 	<Package>retro-gtk</Package>
+	<Package>retro-gtk-devel</Package>
 	<Package>rygel-docs</Package>
 	<Package>telepathy-farstream</Package>
 	<Package>telepathy-farstream-devel</Package>
+	<Package>telepathy-farstream-docs</Package>
 	<Package>telepathy-gabble</Package>
 	<Package>telepathy-haze</Package>
 	<Package>telepathy-morse</Package>
 	<Package>telepathy-qt</Package>
 	<Package>telepathy-qt-devel</Package>
 	<Package>telepathy-rakia</Package>
+	<Package>telepathy-rakia-devel</Package>
 	<Package>telepathy-salut</Package>
 	<Package>uzbl</Package>
 	<Package>vulkan-devel</Package>
 	<Package>vulkan-32bit-devel</Package>
 	<Package>gnutls</Package>
 	<Package>python-faulthandler</Package>
+	<Package>wxPython2</Package>
+	<Package>wxPython2-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -442,5 +442,6 @@
 	<Package>vulkan-devel</Package>
 	<Package>vulkan-32bit-devel</Package>
 	<Package>gnutls</Package>
+	<Package>python-faulthandler</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -589,36 +589,47 @@
 	<Package>empathy</Package>
 	<Package>galculator</Package>
 	<Package>gitg</Package>
+	<Package>gitg-devel</Package>
 	<Package>gnome-code-assistance</Package>
 	<Package>gnome-code-assistance-devel</Package>
 	<Package>gnome-contacts</Package>
 	<Package>gnome-dictionary</Package>
 	<Package>gnome-games</Package>
+	<Package>gnome-games-devel</Package>
 	<Package>gnome-python</Package>
 	<Package>gnome-python-devel</Package>
 	<Package>gnome-python-docs</Package>
 	<Package>gnome-themes-standard</Package>
 	<Package>gnome-themes-standard-32bit</Package>
 	<Package>gnome-todo</Package>
+	<Package>gnome-todo-devel</Package>
+	<Package>gnome-todo-docs</Package>
 	<Package>gtef</Package>
+	<Package>gtef-devel</Package>
+	<Package>gtef-docs</Package>
 	<Package>hardcode-tray</Package>
 	<Package>latexila</Package>
+	<Package>latexila-docs</Package>
 	<Package>libdmapsharing</Package>
 	<Package>libdmapsharing-devel</Package>
+	<Package>libdmapsharing-docs</Package>
 	<Package>libwebkit3-gtk</Package>
 	<Package>libwebkit3-gtk-devel</Package>
 	<Package>libwebkit3-gtk-docs</Package>
 	<Package>pwned-checker</Package>
 	<Package>retro-gtk</Package>
+	<Package>retro-gtk-devel</Package>
 	<Package>rygel-docs</Package>
 	<Package>telepathy-farstream</Package>
 	<Package>telepathy-farstream-devel</Package>
+	<Package>telepathy-farstream-docs</Package>
 	<Package>telepathy-gabble</Package>
 	<Package>telepathy-haze</Package>
 	<Package>telepathy-morse</Package>
 	<Package>telepathy-qt</Package>
 	<Package>telepathy-qt-devel</Package>
 	<Package>telepathy-rakia</Package>
+	<Package>telepathy-rakia-devel</Package>
 	<Package>telepathy-salut</Package>
 	<Package>uzbl</Package>
 
@@ -631,5 +642,9 @@
 
 	<!-- Not required anymore since D1795 //-->
 	<Package>python-faulthandler</Package>
+
+	<!-- No longer used //-->
+	<Package>wxPython2</Package>
+	<Package>wxPython2-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -628,5 +628,8 @@
 
 	<!-- Now named libgnutls-utils //-->
 	<Package>gnutls</Package>
+
+	<!-- Not required anymore since D1795 //-->
+	<Package>python-faulthandler</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
This isn't used anymore since `quodlibet` was ported to python3

Signed-off-by: Pierre-Yves <pyu@riseup.net>