### PR TITLE
Deprecate utopia-documents

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -469,5 +469,6 @@
 	<Package>lbryschema</Package>
 	<Package>lbryum</Package>
 	<Package>kodi-pvr-iptvsimple</Package>
+	<Package>utopia-documents</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -665,5 +665,8 @@
 
 	<!-- merged in with kodi //-->
 	<Package>kodi-pvr-iptvsimple</Package>
+
+	<!-- No upstream activity, slowly breaking against qt updates //-->
+	<Package>utopia-documents</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
No release since at least 2014(?) with no public git. Slowly breaking itself against QT updates
and we have to manually patch it so it rebuilds against new poppler releases.

Signed-off-by: Joey Riches <josephriches@gmail.com>