### PR TITLE
Deprecate gnome-mpv as it has been renamed to celluloid

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -687,5 +687,6 @@
 		<Package>plasma-desktop-devel</Package>
 		<Package>user-manager</Package>
 		<Package>user-manager-dbginfo</Package>
+		<Package>gnome-mpv</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -986,5 +986,8 @@
 		<Package>plasma-desktop-devel</Package>
 		<Package>user-manager</Package>
 		<Package>user-manager-dbginfo</Package>
+
+		<!-- Name changed to celluloid //-->
+    <Package>gnome-mpv</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Part of [D6911](https://dev.getsol.us/D6911).