### PR TITLE
repo_data: Deprecate python3-qtwebengine in favour of python-qtwebengine

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -492,5 +492,6 @@
 		<Package>libpeas-docs</Package>
 		<Package>mariadb-test</Package>
 		<Package>rust-docs</Package>
+		<Package>python3-qtwebengine</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -706,5 +706,8 @@
 
 		<!-- Not needed to purely build packages //-->
 		<Package>rust-docs</Package>
+
+		<!-- Renamed to python-qtwebengine //-->
+		<Package>python3-qtwebengine</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Signed-off-by: Pierre-Yves <pyu@riseup.net>