### PR TITLE
Deprecate aircrack-ng-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -496,6 +496,6 @@
 		<Package>kcalcore</Package>
 		<Package>kcalcore-devel</Package>
 		<Package>kcalcore-dbginfo</Package>
-    <Package>aircrack-ng-devel</Package>
+		<Package>aircrack-ng-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -493,5 +493,6 @@
 		<Package>mariadb-test</Package>
 		<Package>rust-docs</Package>
 		<Package>python3-qtwebengine</Package>
+        <Package>aircrack-ng-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -715,7 +715,7 @@
 		<Package>kcalcore-devel</Package>
 		<Package>kcalcore-dbginfo</Package>
     
-    <!-- Merged in arcrack-ng itself//-->
-    <Package>aircrack-ng-devel</Package>
+		<!-- Merged in arcrack-ng itself//-->
+		<Package>aircrack-ng-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -709,5 +709,8 @@
 
 		<!-- Renamed to python-qtwebengine //-->
 		<Package>python3-qtwebengine</Package>
+
+        <!-- Merged in arcrack-ng itself//-->
+        <Package>aircrack-ng-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
As per [D7293](https://dev.getsol.us/D7293)