### PR TITLE
redshift control now gets shipped by default with Plasma 5.17 so this…

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -493,5 +493,6 @@
 		<Package>mariadb-test</Package>
 		<Package>rust-docs</Package>
 		<Package>python3-qtwebengine</Package>
+		<Package>plasma-redshift-control</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -709,5 +709,8 @@
 
 		<!-- Renamed to python-qtwebengine //-->
 		<Package>python3-qtwebengine</Package>
+
+		<!-- Nightcolor gets shipped now with Plasma 5.17 //-->
+		<Package>plasma-redshift-control</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
… applet is not needed any more