### PR TITLE
remove kcalcore and kpat from the repo

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -494,5 +494,10 @@
 		<Package>rust-docs</Package>
 		<Package>python3-qtwebengine</Package>
 		<Package>plasma-redshift-control</Package>
+		<Package>kpat</Package>
+		<Package>kpat-dbginfo</Package>
+		<Package>kcalcore</Package>
+		<Package>kcalcore-devel</Package>
+		<Package>kcalcore-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -712,5 +712,14 @@
 
 		<!-- Nightcolor gets shipped now with Plasma 5.17 //-->
 		<Package>plasma-redshift-control</Package>
+
+		<!-- needs old python2 to be updated //-->
+		<Package>kpat</Package>
+		<Package>kpat-dbginfo</Package>
+
+		<!-- kcalcore gets replaced by kcalendarcore //-->
+		<Package>kcalcore</Package>
+		<Package>kcalcore-devel</Package>
+		<Package>kcalcore-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
- kcalcore gets replaced by kcalendarcore
- kpat needs old unsupported python2 stuff to be updated