### PR TITLE
Drop dnscrypt-proxy-devel because he doesn't get build anymore and re…

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -494,8 +494,6 @@
 		<Package>rust-docs</Package>
 		<Package>python3-qtwebengine</Package>
 		<Package>plasma-redshift-control</Package>
-		<Package>kpat</Package>
-		<Package>kpat-dbginfo</Package>
 		<Package>kcalcore</Package>
 		<Package>kcalcore-devel</Package>
 		<Package>kcalcore-dbginfo</Package>
@@ -506,5 +504,6 @@
 		<Package>gnome-twitch</Package>
 		<Package>gnome-twitch-devel</Package>
 		<Package>gnome-twitch-dbginfo</Package>
+		<Package>dnscrypt-proxy-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -713,9 +713,6 @@
 		<!-- Nightcolor gets shipped now with Plasma 5.17 //-->
 		<Package>plasma-redshift-control</Package>
 
-		<!-- needs old python2 to be updated //-->
-		<Package>kpat</Package>
-		<Package>kpat-dbginfo</Package>
 
 		<!-- kcalcore gets replaced by kcalendarcore //-->
 		<Package>kcalcore</Package>
@@ -734,5 +731,8 @@
 		<Package>gnome-twitch</Package>
 		<Package>gnome-twitch-devel</Package>
 		<Package>gnome-twitch-dbginfo</Package>
+
+		<!-- remove dnscrypt-proxy-devel because it doesn't get build anymore //-->
+		<Package>dnscrypt-proxy-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
…move kpat from the list because it can now be updated