### PR TITLE
Deprecate sardi-icons-breeze

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -504,5 +504,6 @@
 		<Package>gnome-twitch-devel</Package>
 		<Package>gnome-twitch-dbginfo</Package>
 		<Package>dnscrypt-proxy-devel</Package>
+		<Package>sardi-icons-breeze</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -733,5 +733,8 @@
 
 		<!-- remove dnscrypt-proxy-devel because it doesn't get build anymore //-->
 		<Package>dnscrypt-proxy-devel</Package>
+
+		<!-- breeze was removed from sardi-icons after v.8.2.0 //-->
+		<Package>sardi-icons-breeze</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
sardi-icons-breeze was deprecated on version 8.2.0.
[here](https://dev.getsol.us/R2845:31c54f2e334fdfbb53dc7e2cd545e6be67d847c0) and [here](https://dev.getsol.us/R2845:31c54f2e334fdfbb53dc7e2cd545e6be67d847c0) are the patches on our developers page.