### PR TITLE
Deprecate pgadmin and youtube-dl-gui

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -550,5 +550,7 @@
 		<Package>mrrescue</Package>
 		<Package>sienna</Package>
 		<Package>fontforge-devel</Package>
+        	<package>youtube-dl-gui</package>
+        	<package>pgadmin</package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -804,5 +804,9 @@
 		
 		<!-- Deprecated from FontForge developers. See D8619 //-->
 		<Package>fontforge-devel</Package>
+
+        	<!-- pgadmin has no maintainer on phab and youtube-dl-gui has been dead for 2+ years //-->
+        	<Package>youtube-dl-gui</Package>
+        	<Package>pgadmin</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
These packages are mentioned in [T5974](https://dev.getsol.us/T5974) as having issues using gtk3 version of wxwidgets.
Pgadmin is active upstream, but has not had any maintainer in the repository for two years and `youtube-dl-gui` has been dead upstream for two years.