### PR TITLE
Deprecate gotop and some old package docs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -582,5 +582,23 @@
 		<Package>google-play-music-desktop-player-dbginfo</Package>
 		<Package>uberwriter</Package>
 		<Package>python-wikipedia</Package>
+		<Package>gotop</Package>
+		<Package>digikam-docs</Package>
+		<Package>evolution-data-server-docs</Package>
+		<Package>gexiv2-docs</Package>
+		<Package>gnome-builder-docs</Package>
+		<Package>gnome-shell-docs</Package>
+		<Package>libappindicator-docs</Package>
+		<Package>libgxps-docs</Package>
+		<Package>libjson-glib-docs</Package>
+		<Package>libmediaart-docs</Package>
+		<Package>libosinfo-docs</Package>
+		<Package>libssh2-docs</Package>
+		<Package>libx11-docs</Package>
+		<Package>llvm-docs</Package>
+		<Package>lua-docs</Package>
+		<Package>mutter-docs</Package>
+		<Package>openconnect-docs</Package>
+		<Package>totem-pl-parser-docs</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -854,5 +854,27 @@
 		
 		<!-- Used to be lollypop dependency. Removed in D6879 //-->
 		<Package>python-wikipedia</Package>
+		
+		<!-- Replaced with ytop //-->
+		<Package>gotop</Package>
+		
+		<!-- Some old docs //-->
+		<Package>digikam-docs</Package>
+		<Package>evolution-data-server-docs</Package>
+		<Package>gexiv2-docs</Package>
+		<Package>gnome-builder-docs</Package>
+		<Package>gnome-shell-docs</Package>
+		<Package>libappindicator-docs</Package>
+		<Package>libgxps-docs</Package>
+		<Package>libjson-glib-docs</Package>
+		<Package>libmediaart-docs</Package>
+		<Package>libosinfo-docs</Package>
+		<Package>libssh2-docs</Package>
+		<Package>libx11-docs</Package>
+		<Package>llvm-docs</Package>
+		<Package>lua-docs</Package>
+		<Package>mutter-docs</Package>
+		<Package>openconnect-docs</Package>
+		<Package>totem-pl-parser-docs</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
`gotop` is replaced with `ytop` https://dev.getsol.us/D8299
```
digikam-docs	                - docs removed here: https://dev.getsol.us/R625:d12b42ced6b8fb73db6977f89abaaf6bdde2f90d
evolution-data-server-docs	- version: 3.16.1, release: 4, but evolution-data-server is version: 3.36.3, release: 55
gexiv2-docs			- docs removed here: https://dev.getsol.us/R896:36356eb8aaaf545cf1be04902e263b55d1669d5c
gnome-builder-docs		- version: 3.22.4, release: 20, but gnome-builder is version: 3.36.0, release: 57
gnome-shell-docs		- version: 3.24.3, release: 25, but gnome-shell is version: 3.36.3, release: 59
libappindicator-docs		- docs removed here: https://dev.getsol.us/R1626:813ad172f5b4a662cb01f77ac36afd1acd1f1a57
libgxps-docs			- docs removed here: https://dev.getsol.us/R1727:045bf067ea68025d927b0a636914a89b0f4e85fc
libjson-glib-docs		- docs removed here: https://dev.getsol.us/R1509:106d2c89655934cdd5bff375091c8da7190846d0
libmediaart-docs		- docs removed here: https://dev.getsol.us/R1771:9a93644bd7b4f866e2b25a79681fe9175d9b665d
libosinfo-docs			- docs removed here: https://dev.getsol.us/R1806:7e892a6eeddf4e7e6c5bf52eacacc3b936dbe7e7
libssh2-docs			- docs removed here: https://dev.getsol.us/R1862:076cd033aaf1d37c0fd66ab6035aed0d0ef1d449
libx11-docs			- version: 1.6.3, release: 8, but libx11 is version: 1.6.9, release: 22
llvm-docs			- version: 3.6.2, release: 18, but llvm is version: 9.0.1, release: 72
lua-docs			- version: 5.1.5, release: 2, but lua is version: 5.3.4, release: 5
mutter-docs			- version: 3.16.3, release: 10, but mutter is version: 3.36.3, release: 66
openconnect-docs		- docs not available since here: https://dev.getsol.us/R2233:4a8225ebfa903e7cc373f326b5a982412c43b989
				- After rebuiding: [Package:docs] Did not produce openconnect-docs by any pattern
totem-pl-parser-docs		- docs removed here: https://dev.getsol.us/R3056:2ac9b05c9fb113202fe4aa18a43672f82cece570
```

Some also can't be installed: Like for example installing `mutter-docs`:
```
System error. Program terminated.
mutter-devel release 10 dependency of package mutter-docs is not satisfied