### PR TITLE
Nuking some more python2 packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -610,5 +610,10 @@
 		<Package>openconnect-docs</Package>
 		<Package>totem-pl-parser-docs</Package>
 		<Package>spyder</Package>
+		<Package>python-chess</Package>
+		<Package>python-envparse</Package>
+		<Package>python-photohash</Package>
+		<Package>python2-pylint</Package>
+		<Package>python-seccure</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -894,5 +894,12 @@
 
 		<!-- The beginning of python2 nuking //-->
 		<Package>spyder</Package>
+		
+		<!-- Nuke orphan python2 packages //-->
+		<Package>python-chess</Package>
+		<Package>python-envparse</Package>
+		<Package>python-photohash</Package>
+		<Package>python2-pylint</Package>
+		<Package>python-seccure</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
- `python-chess` - Dependency needed for [LucasChess](https://dev.getsol.us/T5184), but no one stepped up to provide a patch.
- `python-envparse` - Nothing requires it. Initially was used for lbryum. 
- `python-photohash` - Dependency needed for [LucasChess](https://dev.getsol.us/T5184), but no one stepped up to provide a patch.
- `python2-pylint` - Dependency of spyder. No longer needed.
- `python-seccure` - Nothing requires it. Initially was used for lbryum.