### PR TITLE
Deprecate orphan python2 packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -619,5 +619,11 @@
 		<Package>python2-pylint</Package>
 		<Package>python-seccure</Package>
 		<Package>elementary-icon-theme</Package>
+		<Package>python-ipython</Package>
+		<Package>python-pmw</Package>
+		<Package>python-pymol</Package>
+		<Package>python-pymol-dbginfo</Package>
+		<Package>python-trollius</Package>
+		<Package>python-twodict</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -906,5 +906,13 @@
 		<Package>python-seccure</Package>
 
 		<Package>elementary-icon-theme</Package>
+		
+		<!-- Orphan python2 packages //-->
+		<Package>python-ipython</Package>
+		<Package>python-pmw</Package>
+		<Package>python-pymol</Package>
+		<Package>python-pymol-dbginfo</Package>
+		<Package>python-trollius</Package>
+		<Package>python-twodict</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
```
python-ipython			- Python2 Packages. Was dependency of python-ipykernel. Removed here: https://dev.getsol.us/R3715:c97a3dd7d8f95eb88dcdbc6a8cd0d896402f6ba3
python-pmw and python-pymol	- Python2 packages. They aren't used by any existing packages in repository.
python-trollius			- Python2 package. It isn't used by any of existing packages in repository.
python-twodict			- Python2 package. Used to be youtube-dl-gui dependency.
```