### PR TITLE
Deprecate riot because of rename to element

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -625,5 +625,7 @@
 		<Package>python-pymol-dbginfo</Package>
 		<Package>python-trollius</Package>
 		<Package>python-twodict</Package>
+		<Package>riot</Package>
+		<Package>riot-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -914,5 +914,9 @@
 		<Package>python-pymol-dbginfo</Package>
 		<Package>python-trollius</Package>
 		<Package>python-twodict</Package>
+
+		<!-- Renamed from riot to element //-->
+		<Package>riot</Package>
+		<Package>riot-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
See [D9241](https://dev.getsol.us/D9241)