### PR TITLE
Deprecate bundler and ruby-trollop

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -630,5 +630,7 @@
 		<Package>elementary-icon-theme</Package>
 		<Package>riot</Package>
 		<Package>riot-dbginfo</Package>
+		<Package>bundler</Package>
+		<Package>ruby-trollop</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -919,5 +919,9 @@
 		<!-- Renamed from riot to element //-->
 		<Package>riot</Package>
 		<Package>riot-dbginfo</Package>
+		
+		<!-- Repositories are inactive //-->
+		<Package>bundler</Package>
+		<Package>ruby-trollop</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Both repositories are inactive. `ruby-trollop` is replaced with `ruby-optimist`