### PR TITLE
Deprecate python2-astroid and python-fastimport

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -657,7 +657,10 @@
 		<Package>python-trollius</Package>
 		<Package>python-twodict</Package>
 		<Package>python-fastimport</Package>
+		<Package>python-gmpy</Package>
+		<Package>python-gmpy-dbginfo</Package>
 		<Package>python2-astroid</Package>
+		<Package>python3-mpmath</Package>
 		<Package>elementary-icon-theme</Package>
 		<Package>riot</Package>
 		<Package>riot-dbginfo</Package>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -656,6 +656,8 @@
 		<Package>python-pymol-dbginfo</Package>
 		<Package>python-trollius</Package>
 		<Package>python-twodict</Package>
+		<Package>python-fastimport</Package>
+		<Package>python2-astroid</Package>
 		<Package>elementary-icon-theme</Package>
 		<Package>riot</Package>
 		<Package>riot-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -942,6 +942,8 @@
 		<Package>python-pymol-dbginfo</Package>
 		<Package>python-trollius</Package>
 		<Package>python-twodict</Package>
+		<Package>python-fastimport</Package>
+		<Package>python2-astroid</Package>
 
 		<Package>elementary-icon-theme</Package>
 

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -943,7 +943,10 @@
 		<Package>python-trollius</Package>
 		<Package>python-twodict</Package>
 		<Package>python-fastimport</Package>
+		<Package>python-gmpy</Package>
+		<Package>python-gmpy-dbginfo</Package>
 		<Package>python2-astroid</Package>
+		<Package>python3-mpmath</Package>
 
 		<Package>elementary-icon-theme</Package>
 


### PR DESCRIPTION
These are orphan python2 packages.
python2-astroid - Nothing is using it anymore
python-fastimport - Dependency of `bzr-fastimport` but this one isn't yet in repository. https://dev.getsol.us/D2937.