### PR TITLE
Deprecate python-polib, python-osinfo and conan python dependencies

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -327,6 +327,10 @@
 		<Package>partclone</Package>
 		<Package>profanity</Package>
 		<Package>profanity-devel</Package>
+		<Package>python-deprecation</Package>
+		<Package>python-node-semver</Package>
+		<Package>python-patch</Package>
+		<Package>python-pluginbase</Package>
 		<Package>roxterm</Package>
 		<Package>sabnzbd</Package>
 		<Package>vault</Package>
@@ -665,5 +669,7 @@
 		<Package>riot-dbginfo</Package>
 		<Package>bundler</Package>
 		<Package>ruby-trollop</Package>
+		<Package>python-osinfo</Package>
+		<Package>python-polib</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -479,6 +479,10 @@
 		<Package>partclone</Package>
 		<Package>profanity</Package>
 		<Package>profanity-devel</Package>
+		<Package>python-deprecation</Package>
+		<Package>python-node-semver</Package>
+		<Package>python-patch</Package>
+		<Package>python-pluginbase</Package>
 		<Package>roxterm</Package>
 		<Package>sabnzbd</Package>
 		<Package>vault</Package>
@@ -956,5 +960,9 @@
 		<!-- Repositories are inactive //-->
 		<Package>bundler</Package>
 		<Package>ruby-trollop</Package>
+		
+		<!-- Orphan python packages //-->
+		<Package>python-osinfo</Package>
+		<Package>python-polib</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
- python-deprecation, python-node-semver, python-patch, python-pluginbase are no longer required as per deprecation of `conan`. These packages aren't used by any other packages in repository.

- python-polib and python-osinfo both are built with python2 and python3 and they are orphan packages.
I didn't find any reference why these packages are added to repo in first place. If we are going to keep these, then we just have to deprecate python2 support.