### PR TITLE
Deprecate http-prompt

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -679,5 +679,7 @@
 		<Package>tootle-dbginfo</Package>
 		<Package>python-osinfo</Package>
 		<Package>python-polib</Package>
+		<Package>http-prompt</Package>
+		<Package>python-parsimonious</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -972,5 +972,9 @@
 		<!-- Orphan python packages //-->
 		<Package>python-osinfo</Package>
 		<Package>python-polib</Package>
+		
+		<!-- http-prompt broken because requires older python-modules //-->
+		<Package>http-prompt</Package>
+		<Package>python-parsimonious</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
`http-prompt` currently is broken because it requires old versions of `python-prompt-toolkit`. By doing this we have to rollback `spyder3` to v3.x.x series.

`python-parsimonious` is required only by `http-prompt`.
`httpie` is required also by `http-prompt`, but I didn't add it to this PR because I wasn't sure if it need deprecated, since originally this package wasn't added into the repo because of `http-prompt`.