### PR TITLE
Deprecate helm (synthesizer), no changes since 2018

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -687,5 +687,6 @@
 		<Package>plasma-desktop-devel</Package>
 		<Package>user-manager</Package>
 		<Package>user-manager-dbginfo</Package>
+		<Package>helm</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -688,5 +688,6 @@
 		<Package>user-manager</Package>
 		<Package>user-manager-dbginfo</Package>
 		<Package>helm</Package>
+		<Package>helm-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -986,5 +986,8 @@
 		<Package>plasma-desktop-devel</Package>
 		<Package>user-manager</Package>
 		<Package>user-manager-dbginfo</Package>
+
+		<!-- Upstream has not seen changes since 2018 //-->
+		<Package>helm</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -989,5 +989,6 @@
 
 		<!-- Upstream has not seen changes since 2018 //-->
 		<Package>helm</Package>
+		<Package>helm-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
This is one of the best open source synthesizers available, but the develop seems to have totally lost interest in making new changes, answering comments or even merging pull requests. I see no other solution than to drop it out sadly.