### PR TITLE
Deprecate ETL-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -726,5 +726,6 @@
 		<Package>libunique-docs</Package>
 		<Package>vino</Package>
 		<Package>vino-dbginfo</Package>
+		<Package>ETL-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1029,5 +1029,8 @@
 		<Package>libunique-docs</Package>
 		<Package>vino</Package>
 		<Package>vino-dbginfo</Package>
+
+		<!-- All files has been patterned into main package, as ETL is a header-only library //-->
+		<Package>ETL-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
I have patterned all files into the main package, just like we do with other header-only libraries. ETL-devel package is now obsolete.