### PR TITLE
Deprecate old doc packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -654,9 +654,13 @@
 		<Package>wlc</Package>
 		<Package>wlc-dbginfo</Package>
 		<Package>wlc-devel</Package>
+		<Package>clutter-gst-2.0-docs</Package>
+		<Package>dconf-docs</Package>
 		<Package>digikam-docs</Package>
+		<Package>eog-docs</Package>
 		<Package>evolution-data-server-docs</Package>
 		<Package>gexiv2-docs</Package>
+		<Package>glib2-docs</Package>
 		<Package>gnome-builder-docs</Package>
 		<Package>gnome-shell-docs</Package>
 		<Package>libappindicator-docs</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -936,9 +936,13 @@
 		<Package>wlc-devel</Package>
 		
 		<!-- Some old docs //-->
+		<Package>clutter-gst-2.0-docs</Package>
+		<Package>dconf-docs</Package>
 		<Package>digikam-docs</Package>
+		<Package>eog-docs</Package>
 		<Package>evolution-data-server-docs</Package>
 		<Package>gexiv2-docs</Package>
+		<Package>glib2-docs</Package>
 		<Package>gnome-builder-docs</Package>
 		<Package>gnome-shell-docs</Package>
 		<Package>libappindicator-docs</Package>


### PR DESCRIPTION
These are some old doc packages that I think we should deprecate them. They are not getting updated alongside the main package.