### PR TITLE
Deprecate old dbginfo packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -747,6 +747,34 @@
 		<Package>libunique-docs</Package>
 		<Package>vino</Package>
 		<Package>vino-dbginfo</Package>
+		<Package>CGAL-dbginfo</Package>
+		<Package>apache-maven-32bit-dbginfo</Package>
+		<Package>breeze-gtk-theme-dbginfo</Package>
+		<Package>exfat-utils-dbginfo</Package>
+		<Package>finch-dbginfo</Package>
+		<Package>freefilesync-dbginfo</Package>
+		<Package>glm-dbginfo</Package>
+		<Package>gtk3-icon-browser-dbginfo</Package>
+		<Package>libcacard-dbginfo</Package>
+		<Package>libfakekey-dbginfo</Package>
+		<Package>liblouis-dbginfo</Package>
+		<Package>libparted-dbginfo</Package>
+		<Package>libpurple-dbginfo</Package>
+		<Package>libvala-devel-dbginfo</Package>
+		<Package>nettle-bin-dbginfo</Package>
+		<Package>nvidia-glx-driver-32bit-dbginfo</Package>
+		<Package>nvidia-glx-driver-dbginfo</Package>
+		<Package>openssh-server-dbginfo</Package>
+		<Package>psutils-dbginfo</Package>
+		<Package>qgis-32bit-dbginfo</Package>
+		<Package>soundtouch-32bit-dbginfo</Package>
+		<Package>soundtouch-dbginfo</Package>
+		<Package>tensorflow-dbginfo</Package>
+		<Package>the-widget-factory-3-dbginfo</Package>
+		<Package>unixodbc-32bit-dbginfo</Package>
+		<Package>unixodbc-dbginfo</Package>
+		<Package>vagrant-dbginfo</Package>
+		<Package>valadoc-dbginfo</Package>
 		<Package>ETL-devel</Package>
 		<Package>python-pygpgme</Package>
 		<Package>kdepim-apps-libs</Package>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -135,10 +135,17 @@
 		<Package>gnome-dictionary-devel</Package>
 		<Package>gnome-initial-setup</Package>
 		<Package>gnome-shell-extension-caffeine</Package>
+		<Package>libgee1</Package>
+		<Package>libgee1-devel</Package>
+		<Package>libgee1-dbginfo</Package>
 		<Package>mozjs17</Package>
 		<Package>mozjs17-devel</Package>
+		<Package>redo</Package>
 		<Package>spidermonkey</Package>
 		<Package>spidermonkey-devel</Package>
+		<Package>vte2</Package>
+		<Package>vte2-devel</Package>
+		<Package>vte2-dbginfo</Package>
 		<Package>zlib-minizip-32bit</Package>
 		<Package>zlib-minizip-devel-32bit</Package>
 		<Package>gnonlin</Package>
@@ -159,6 +166,8 @@
 		<Package>qupzilla</Package>
 		<Package>qupzilla-devel</Package>
 		<Package>cutegram</Package>
+		<Package>lilyterm</Package>
+		<Package>lilyterm-dbginfo</Package>
 		<Package>livestreamer</Package>
 		<Package>flat-plat-gtk-theme</Package>
 		<Package>flat-plat-gtk-theme-compact</Package>
@@ -327,10 +336,12 @@
 		<Package>nitrokey-app</Package>
 		<Package>openbazaar</Package>
 		<Package>openbazaard</Package>
+		<Package>osmo</Package>
 		<Package>packer</Package>
 		<Package>partclone</Package>
 		<Package>profanity</Package>
 		<Package>profanity-devel</Package>
+		<Package>pithos</Package>
 		<Package>python-deprecation</Package>
 		<Package>python-node-semver</Package>
 		<Package>python-patch</Package>
@@ -339,9 +350,13 @@
 		<Package>rolisteam-dbginfo</Package>
 		<Package>roxterm</Package>
 		<Package>sabnzbd</Package>
+		<Package>sunflower</Package>
+		<Package>syncplay</Package>
 		<Package>tellico</Package>
 		<Package>tellico-dbginfo</Package>
 		<Package>vault</Package>
+		<Package>yakyak</Package>
+		<Package>yakyak-dbginfo</Package>
 		<Package>libnfsidmap</Package>
 		<Package>libnfsidmap-devel</Package>
 		<Package>opal</Package>
@@ -654,6 +669,7 @@
 		<Package>wlc</Package>
 		<Package>wlc-dbginfo</Package>
 		<Package>wlc-devel</Package>
+		<Package>atkmm-docs</Package>
 		<Package>clutter-gst-2.0-docs</Package>
 		<Package>dconf-docs</Package>
 		<Package>digikam-docs</Package>
@@ -733,33 +749,8 @@
 		<Package>vino-dbginfo</Package>
 		<Package>ETL-devel</Package>
 		<Package>python-pygpgme</Package>
-		<Package>CGAL-dbginfo</Package>
-		<Package>apache-maven-32bit-dbginfo</Package>
-		<Package>breeze-gtk-theme-dbginfo</Package>
-		<Package>exfat-utils-dbginfo</Package>
-		<Package>finch-dbginfo</Package>
-		<Package>freefilesync-dbginfo</Package>
-		<Package>glm-dbginfo</Package>
-		<Package>gtk3-icon-browser-dbginfo</Package>
-		<Package>libcacard-dbginfo</Package>
-		<Package>libfakekey-dbginfo</Package>
-		<Package>liblouis-dbginfo</Package>
-		<Package>libparted-dbginfo</Package>
-		<Package>libpurple-dbginfo</Package>
-		<Package>libvala-devel-dbginfo</Package>
-		<Package>nettle-bin-dbginfo</Package>
-		<Package>nvidia-glx-driver-32bit-dbginfo</Package>
-		<Package>nvidia-glx-driver-dbginfo</Package>
-		<Package>openssh-server-dbginfo</Package>
-		<Package>psutils-dbginfo</Package>
-		<Package>qgis-32bit-dbginfo</Package>
-		<Package>soundtouch-32bit-dbginfo</Package>
-		<Package>soundtouch-dbginfo</Package>
-		<Package>tensorflow-dbginfo</Package>
-		<Package>the-widget-factory-3-dbginfo</Package>
-		<Package>unixodbc-32bit-dbginfo</Package>
-		<Package>unixodbc-dbginfo</Package>
-		<Package>vagrant-dbginfo</Package>
-		<Package>valadoc-dbginfo</Package>
+		<Package>kdepim-apps-libs</Package>
+		<Package>kdepim-apps-libs-devel</Package>
+		<Package>kdepim-apps-libs-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -733,5 +733,33 @@
 		<Package>vino-dbginfo</Package>
 		<Package>ETL-devel</Package>
 		<Package>python-pygpgme</Package>
+		<Package>CGAL-dbginfo</Package>
+		<Package>apache-maven-32bit-dbginfo</Package>
+		<Package>breeze-gtk-theme-dbginfo</Package>
+		<Package>exfat-utils-dbginfo</Package>
+		<Package>finch-dbginfo</Package>
+		<Package>freefilesync-dbginfo</Package>
+		<Package>glm-dbginfo</Package>
+		<Package>gtk3-icon-browser-dbginfo</Package>
+		<Package>libcacard-dbginfo</Package>
+		<Package>libfakekey-dbginfo</Package>
+		<Package>liblouis-dbginfo</Package>
+		<Package>libparted-dbginfo</Package>
+		<Package>libpurple-dbginfo</Package>
+		<Package>libvala-devel-dbginfo</Package>
+		<Package>nettle-bin-dbginfo</Package>
+		<Package>nvidia-glx-driver-32bit-dbginfo</Package>
+		<Package>nvidia-glx-driver-dbginfo</Package>
+		<Package>openssh-server-dbginfo</Package>
+		<Package>psutils-dbginfo</Package>
+		<Package>qgis-32bit-dbginfo</Package>
+		<Package>soundtouch-32bit-dbginfo</Package>
+		<Package>soundtouch-dbginfo</Package>
+		<Package>tensorflow-dbginfo</Package>
+		<Package>the-widget-factory-3-dbginfo</Package>
+		<Package>unixodbc-32bit-dbginfo</Package>
+		<Package>unixodbc-dbginfo</Package>
+		<Package>vagrant-dbginfo</Package>
+		<Package>valadoc-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1050,6 +1050,36 @@
 		<Package>libunique-docs</Package>
 		<Package>vino</Package>
 		<Package>vino-dbginfo</Package>
+		
+		<!-- Clean dbginfo packages //-->
+		<Package>CGAL-dbginfo</Package>
+		<Package>apache-maven-32bit-dbginfo</Package>
+		<Package>breeze-gtk-theme-dbginfo</Package>
+		<Package>exfat-utils-dbginfo</Package>
+		<Package>finch-dbginfo</Package>
+		<Package>freefilesync-dbginfo</Package>
+		<Package>glm-dbginfo</Package>
+		<Package>gtk3-icon-browser-dbginfo</Package>
+		<Package>libcacard-dbginfo</Package>
+		<Package>libfakekey-dbginfo</Package>
+		<Package>liblouis-dbginfo</Package>
+		<Package>libparted-dbginfo</Package>
+		<Package>libpurple-dbginfo</Package>
+		<Package>libvala-devel-dbginfo</Package>
+		<Package>nettle-bin-dbginfo</Package>
+		<Package>nvidia-glx-driver-32bit-dbginfo</Package>
+		<Package>nvidia-glx-driver-dbginfo</Package>
+		<Package>openssh-server-dbginfo</Package>
+		<Package>psutils-dbginfo</Package>
+		<Package>qgis-32bit-dbginfo</Package>
+		<Package>soundtouch-32bit-dbginfo</Package>
+		<Package>soundtouch-dbginfo</Package>
+		<Package>tensorflow-dbginfo</Package>
+		<Package>the-widget-factory-3-dbginfo</Package>
+		<Package>unixodbc-32bit-dbginfo</Package>
+		<Package>unixodbc-dbginfo</Package>
+		<Package>vagrant-dbginfo</Package>
+		<Package>valadoc-dbginfo</Package>
 
 		<!-- All files has been patterned into main package, as ETL is a header-only library //-->
 		<Package>ETL-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1040,5 +1040,35 @@
 		
 		<!-- Orphan python2 package -->
 		<Package>python-pygpgme</Package>
+
+		<!-- Clean dbginfo packages //-->
+		<Package>CGAL-dbginfo</Package>
+		<Package>apache-maven-32bit-dbginfo</Package>
+		<Package>breeze-gtk-theme-dbginfo</Package>
+		<Package>exfat-utils-dbginfo</Package>
+		<Package>finch-dbginfo</Package>
+		<Package>freefilesync-dbginfo</Package>
+		<Package>glm-dbginfo</Package>
+		<Package>gtk3-icon-browser-dbginfo</Package>
+		<Package>libcacard-dbginfo</Package>
+		<Package>libfakekey-dbginfo</Package>
+		<Package>liblouis-dbginfo</Package>
+		<Package>libparted-dbginfo</Package>
+		<Package>libpurple-dbginfo</Package>
+		<Package>libvala-devel-dbginfo</Package>
+		<Package>nettle-bin-dbginfo</Package>
+		<Package>nvidia-glx-driver-32bit-dbginfo</Package>
+		<Package>nvidia-glx-driver-dbginfo</Package>
+		<Package>openssh-server-dbginfo</Package>
+		<Package>psutils-dbginfo</Package>
+		<Package>qgis-32bit-dbginfo</Package>
+		<Package>soundtouch-32bit-dbginfo</Package>
+		<Package>soundtouch-dbginfo</Package>
+		<Package>tensorflow-dbginfo</Package>
+		<Package>the-widget-factory-3-dbginfo</Package>
+		<Package>unixodbc-32bit-dbginfo</Package>
+		<Package>unixodbc-dbginfo</Package>
+		<Package>vagrant-dbginfo</Package>
+		<Package>valadoc-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -193,10 +193,17 @@
 		<Package>gnome-shell-extension-caffeine</Package>
 
 		<!-- No longer used for anything //-->
+		<Package>libgee1</Package>
+		<Package>libgee1-devel</Package>
+		<Package>libgee1-dbginfo</Package>
 		<Package>mozjs17</Package>
 		<Package>mozjs17-devel</Package>
+		<Package>redo</Package>
 		<Package>spidermonkey</Package>
 		<Package>spidermonkey-devel</Package>
+		<Package>vte2</Package>
+		<Package>vte2-devel</Package>
+		<Package>vte2-dbginfo</Package>
 
 		<Package>zlib-minizip-32bit</Package>
 		<Package>zlib-minizip-devel-32bit</Package>
@@ -246,6 +253,8 @@
 
 		<!-- Dead upstream. Deprecating package. //-->
 		<Package>cutegram</Package>
+		<Package>lilyterm</Package>
+		<Package>lilyterm-dbginfo</Package>
 
 		<!-- Dead upstream, replaced by fork streamlink //-->
 		<Package>livestreamer</Package>
@@ -481,10 +490,12 @@
 		<Package>nitrokey-app</Package>
 		<Package>openbazaar</Package>
 		<Package>openbazaard</Package>
+		<Package>osmo</Package>
 		<Package>packer</Package>
 		<Package>partclone</Package>
 		<Package>profanity</Package>
 		<Package>profanity-devel</Package>
+		<Package>pithos</Package>
 		<Package>python-deprecation</Package>
 		<Package>python-node-semver</Package>
 		<Package>python-patch</Package>
@@ -493,9 +504,13 @@
 		<Package>rolisteam-dbginfo</Package>
 		<Package>roxterm</Package>
 		<Package>sabnzbd</Package>
+		<Package>sunflower</Package>
+		<Package>syncplay</Package>
 		<Package>tellico</Package>
 		<Package>tellico-dbginfo</Package>
 		<Package>vault</Package>
+		<Package>yakyak</Package>
+		<Package>yakyak-dbginfo</Package>
 
 		<!-- Replaced by nfs-utils //-->
 		<Package>libnfsidmap</Package>
@@ -936,6 +951,7 @@
 		<Package>wlc-devel</Package>
 		
 		<!-- Some old docs //-->
+		<Package>atkmm-docs</Package>
 		<Package>clutter-gst-2.0-docs</Package>
 		<Package>dconf-docs</Package>
 		<Package>digikam-docs</Package>
@@ -1037,38 +1053,13 @@
 
 		<!-- All files has been patterned into main package, as ETL is a header-only library //-->
 		<Package>ETL-devel</Package>
-		
+
 		<!-- Orphan python2 package -->
 		<Package>python-pygpgme</Package>
 
-		<!-- Clean dbginfo packages //-->
-		<Package>CGAL-dbginfo</Package>
-		<Package>apache-maven-32bit-dbginfo</Package>
-		<Package>breeze-gtk-theme-dbginfo</Package>
-		<Package>exfat-utils-dbginfo</Package>
-		<Package>finch-dbginfo</Package>
-		<Package>freefilesync-dbginfo</Package>
-		<Package>glm-dbginfo</Package>
-		<Package>gtk3-icon-browser-dbginfo</Package>
-		<Package>libcacard-dbginfo</Package>
-		<Package>libfakekey-dbginfo</Package>
-		<Package>liblouis-dbginfo</Package>
-		<Package>libparted-dbginfo</Package>
-		<Package>libpurple-dbginfo</Package>
-		<Package>libvala-devel-dbginfo</Package>
-		<Package>nettle-bin-dbginfo</Package>
-		<Package>nvidia-glx-driver-32bit-dbginfo</Package>
-		<Package>nvidia-glx-driver-dbginfo</Package>
-		<Package>openssh-server-dbginfo</Package>
-		<Package>psutils-dbginfo</Package>
-		<Package>qgis-32bit-dbginfo</Package>
-		<Package>soundtouch-32bit-dbginfo</Package>
-		<Package>soundtouch-dbginfo</Package>
-		<Package>tensorflow-dbginfo</Package>
-		<Package>the-widget-factory-3-dbginfo</Package>
-		<Package>unixodbc-32bit-dbginfo</Package>
-		<Package>unixodbc-dbginfo</Package>
-		<Package>vagrant-dbginfo</Package>
-		<Package>valadoc-dbginfo</Package>
+		<!-- kdepim-apps-libs is no more -->
+		<Package>kdepim-apps-libs</Package>
+		<Package>kdepim-apps-libs-devel</Package>
+		<Package>kdepim-apps-libs-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
All these packages the release number don't match with the main packages. They are all uninstallable.
```
breeze-gtk-theme-dbginfo
CGAL-dbginfo
exfat-utils-dbginfo
finch-dbginfo
freefilesync-dbginfo
glm-dbginfo
gtk3-icon-browser-dbginfo
libcacard-dbginfo
libfakekey-dbginfo
liblouis-dbginfo
libparted-dbginfo
libpurple-dbginfo
libvala-devel-dbginfo
nettle-bin-dbginfo
nvidia-glx-driver-32bit-dbginfo
nvidia-glx-driver-dbginfo
openssh-server-dbginfo
psutils-dbginfo
soundtouch-32bit-dbginfo
soundtouch-dbginfo
tensorflow-dbginfo
the-widget-factory-3-dbginfo
unixodbc-32bit-dbginfo
unixodbc-dbginfo
vagrant-dbginfo
valadoc-dbginfo
```

`apache-maven-32bit-dbginfo` and `qgis-32bit-dbginfo` can be installed but again their release numbers don't match with the main package.