### PR TITLE
Deprecate dolphin-emu-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -736,5 +736,6 @@
 		<Package>kdepim-apps-libs</Package>
 		<Package>kdepim-apps-libs-devel</Package>
 		<Package>kdepim-apps-libs-dbginfo</Package>
+		<Package>dolphin-emu-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1045,5 +1045,8 @@
 		<Package>kdepim-apps-libs</Package>
 		<Package>kdepim-apps-libs-devel</Package>
 		<Package>kdepim-apps-libs-dbginfo</Package>
+
+		<!-- The -devel package is no longer built //-->
+		<Package>dolphin-emu-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Included Discord RPC headers that did not need to be installed