### PR TITLE
Remove old dbginfo packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -751,6 +751,34 @@
 		<Package>libunique-docs</Package>
 		<Package>vino</Package>
 		<Package>vino-dbginfo</Package>
+		<Package>CGAL-dbginfo</Package>
+		<Package>apache-maven-32bit-dbginfo</Package>
+		<Package>breeze-gtk-theme-dbginfo</Package>
+		<Package>exfat-utils-dbginfo</Package>
+		<Package>finch-dbginfo</Package>
+		<Package>freefilesync-dbginfo</Package>
+		<Package>glm-dbginfo</Package>
+		<Package>gtk3-icon-browser-dbginfo</Package>
+		<Package>libcacard-dbginfo</Package>
+		<Package>libfakekey-dbginfo</Package>
+		<Package>liblouis-dbginfo</Package>
+		<Package>libparted-dbginfo</Package>
+		<Package>libpurple-dbginfo</Package>
+		<Package>libvala-devel-dbginfo</Package>
+		<Package>nettle-bin-dbginfo</Package>
+		<Package>nvidia-glx-driver-32bit-dbginfo</Package>
+		<Package>nvidia-glx-driver-dbginfo</Package>
+		<Package>openssh-server-dbginfo</Package>
+		<Package>psutils-dbginfo</Package>
+		<Package>qgis-32bit-dbginfo</Package>
+		<Package>soundtouch-32bit-dbginfo</Package>
+		<Package>soundtouch-dbginfo</Package>
+		<Package>tensorflow-dbginfo</Package>
+		<Package>the-widget-factory-3-dbginfo</Package>
+		<Package>unixodbc-32bit-dbginfo</Package>
+		<Package>unixodbc-dbginfo</Package>
+		<Package>vagrant-dbginfo</Package>
+		<Package>valadoc-dbginfo</Package>
 		<Package>ETL-devel</Package>
 		<Package>python-pygpgme</Package>
 		<Package>kdepim-apps-libs</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1054,6 +1054,36 @@
 		<Package>libunique-docs</Package>
 		<Package>vino</Package>
 		<Package>vino-dbginfo</Package>
+		
+		<!-- Remove old dbginfo packages //-->
+		<Package>CGAL-dbginfo</Package>
+		<Package>apache-maven-32bit-dbginfo</Package>
+		<Package>breeze-gtk-theme-dbginfo</Package>
+		<Package>exfat-utils-dbginfo</Package>
+		<Package>finch-dbginfo</Package>
+		<Package>freefilesync-dbginfo</Package>
+		<Package>glm-dbginfo</Package>
+		<Package>gtk3-icon-browser-dbginfo</Package>
+		<Package>libcacard-dbginfo</Package>
+		<Package>libfakekey-dbginfo</Package>
+		<Package>liblouis-dbginfo</Package>
+		<Package>libparted-dbginfo</Package>
+		<Package>libpurple-dbginfo</Package>
+		<Package>libvala-devel-dbginfo</Package>
+		<Package>nettle-bin-dbginfo</Package>
+		<Package>nvidia-glx-driver-32bit-dbginfo</Package>
+		<Package>nvidia-glx-driver-dbginfo</Package>
+		<Package>openssh-server-dbginfo</Package>
+		<Package>psutils-dbginfo</Package>
+		<Package>qgis-32bit-dbginfo</Package>
+		<Package>soundtouch-32bit-dbginfo</Package>
+		<Package>soundtouch-dbginfo</Package>
+		<Package>tensorflow-dbginfo</Package>
+		<Package>the-widget-factory-3-dbginfo</Package>
+		<Package>unixodbc-32bit-dbginfo</Package>
+		<Package>unixodbc-dbginfo</Package>
+		<Package>vagrant-dbginfo</Package>
+		<Package>valadoc-dbginfo</Package>
 
 		<!-- All files has been patterned into main package, as ETL is a header-only library //-->
 		<Package>ETL-devel</Package>


### PR DESCRIPTION
All these packages the release number don't match with the main packages. They are all uninstallable.
```
breeze-gtk-theme-dbginfo
CGAL-dbginfo
exfat-utils-dbginfo
finch-dbginfo
freefilesync-dbginfo
glm-dbginfo
gtk3-icon-browser-dbginfo
libcacard-dbginfo
libfakekey-dbginfo
liblouis-dbginfo
libparted-dbginfo
libpurple-dbginfo
libvala-devel-dbginfo
nettle-bin-dbginfo
nvidia-glx-driver-32bit-dbginfo
nvidia-glx-driver-dbginfo
openssh-server-dbginfo
psutils-dbginfo
soundtouch-32bit-dbginfo
soundtouch-dbginfo
tensorflow-dbginfo
the-widget-factory-3-dbginfo
unixodbc-32bit-dbginfo
unixodbc-dbginfo
vagrant-dbginfo
valadoc-dbginfo
```

`apache-maven-32bit-dbginfo` and `qgis-32bit-dbginfo` can be installed but again their release numbers don't match with the main package.