### PR TITLE
Deprecate some unnecessary python packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -712,6 +712,9 @@
 		<Package>python-gmpy-dbginfo</Package>
 		<Package>python2-astroid</Package>
 		<Package>python3-mpmath</Package>
+		<Package>python-logilab-common</Package>
+		<Package>python-backports.unittest_mock</Package>
+		<Package>python-base58</Package>
 		<Package>elementary-icon-theme</Package>
 		<Package>riot</Package>
 		<Package>riot-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -998,6 +998,9 @@
 		<Package>python-gmpy-dbginfo</Package>
 		<Package>python2-astroid</Package>
 		<Package>python3-mpmath</Package>
+		<Package>python-logilab-common</Package>
+		<Package>python-backports.unittest_mock</Package>
+		<Package>python-base58</Package>
 
 		<Package>elementary-icon-theme</Package>
 


### PR DESCRIPTION
These are orphan python packages
```
python-logilab-common - From D633 dependency of pylint. Removed on D3348. Removed from pylint after 1.5.0.
(https://github.com/PyCQA/pylint/blob/pylint-2.0.1/ChangeLog#L1573)
python-base58 - Initially was required for lbry
python-backports.unittest_mock	- Required for python-keyrings.alt but it is deprecated now.
```