### PR TITLE
Undeprecate Aegisub

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -585,8 +585,6 @@
 		<Package>nvidia-340-glx-driver-current</Package>
 		<Package>nvidia-340-glx-driver-modaliases</Package>
 		<Package>nvidia-340-glx-driver</Package>
-		<Package>aegisub</Package>
-		<Package>aegisub-dbginfo</Package>
 		<Package>cerebro</Package>
 		<Package>cerebro-dbginfo</Package>
 		<Package>clisp</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -824,8 +824,6 @@
 		<Package>nvidia-340-glx-driver</Package>
 
 		<!-- 2019 and 2020 cleanup //-->
-		<Package>aegisub</Package>
-		<Package>aegisub-dbginfo</Package>
 		<Package>cerebro</Package>
 		<Package>cerebro-dbginfo</Package>
 		<Package>clisp</Package>


### PR DESCRIPTION
Switching Aegisub to a fork maintained by wangqr. Update submitted [here](https://dev.getsol.us/D10281).