### PR TITLE
Cleaning some packages from the repo

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -664,6 +664,8 @@
 		<Package>uberwriter</Package>
 		<Package>python-wikipedia</Package>
 		<Package>vcmi-devel</Package>
+		<Package>cava-devel</Package>
+		<Package>scribus-devel</Package>
 		<Package>compton</Package>
 		<Package>gotop</Package>
 		<Package>ytop</Package>
@@ -693,6 +695,15 @@
 		<Package>mutter-docs</Package>
 		<Package>openconnect-docs</Package>
 		<Package>totem-pl-parser-docs</Package>
+		<Package>gstreamer-1.0-libav-docs</Package>
+		<Package>libgdata-docs</Package>
+		<Package>libu2f-host-docs</Package>
+		<Package>libu2f-server-docs</Package>
+		<Package>libcairomm-docs</Package>
+		<Package>tepl-docs</Package>
+		<Package>tracker-docs</Package>
+		<Package>python3-guessit</Package>
+		<Package>libidn-utils</Package>
 		<Package>spyder</Package>
 		<Package>python-chess</Package>
 		<Package>python-envparse</Package>
@@ -780,6 +791,11 @@
 		<Package>unixodbc-dbginfo</Package>
 		<Package>vagrant-dbginfo</Package>
 		<Package>valadoc-dbginfo</Package>
+		<Package>python-jedi-dbginfo</Package>
+		<Package>python3-jedi-dbginfo</Package>
+		<Package>python3-sip-dbginfo</Package>
+		<Package>bazel-dbginfo</Package>
+		<Package>python-mistune-dbginfo</Package>
 		<Package>ETL-devel</Package>
 		<Package>python-pygpgme</Package>
 		<Package>kdepim-apps-libs</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -940,6 +940,8 @@
 
 		<!-- No more devel package //-->
 		<Package>vcmi-devel</Package>
+		<Package>cava-devel</Package>
+		<Package>scribus-devel</Package>
 		
 		<!-- Renamed from compton to picom //-->
 		<Package>compton</Package>
@@ -975,6 +977,19 @@
 		<Package>mutter-docs</Package>
 		<Package>openconnect-docs</Package>
 		<Package>totem-pl-parser-docs</Package>
+		<Package>gstreamer-1.0-libav-docs</Package>
+		<Package>libgdata-docs</Package>
+		<Package>libu2f-host-docs</Package>
+		<Package>libu2f-server-docs</Package>
+		<Package>libcairomm-docs</Package>
+		<Package>tepl-docs</Package>
+		<Package>tracker-docs</Package>
+
+		<!-- Dublicate of python-guessit //-->
+		<Package>python3-guessit</Package>
+
+		<!-- Not avalilable after converting to ypkg //-->
+		<Package>libidn-utils</Package>
 
 		<!-- The beginning of python2 nuking //-->
 		<Package>spyder</Package>
@@ -1085,6 +1100,11 @@
 		<Package>unixodbc-dbginfo</Package>
 		<Package>vagrant-dbginfo</Package>
 		<Package>valadoc-dbginfo</Package>
+		<Package>python-jedi-dbginfo</Package>
+		<Package>python3-jedi-dbginfo</Package>
+		<Package>python3-sip-dbginfo</Package>
+		<Package>bazel-dbginfo</Package>
+		<Package>python-mistune-dbginfo</Package>
 
 		<!-- All files has been patterned into main package, as ETL is a header-only library //-->
 		<Package>ETL-devel</Package>


### PR DESCRIPTION
Old doc packages in the brackets is the commit when these docs disappeared.
- gstreamer-1.0-libav-docs (a609771b2f59)
- libgdata-docs (502aa650360b)
- libu2f-host-docs (9f5daf414417)
- libu2f-server-docs (852f7a047b78)
- libcairomm-docs (libcairomm is a deprecated package)
- tepl-docs (32a2f88a541b)
- tracker-docs (52c121756037)

Dublicate packages
- python3-guessit (dublicate of python-guessit)

Old dbginfo packages
- python-jedi-dbginfo
- python3-jedi-dbginfo
- python3-sip-dbginfo
- bazel-dbginfo
- python-mistune-dbginfo

Old devel pacakges
- cava-devel
- scribus-devel

Other
- libidn-utils