### PR TITLE
Conserve changelog bullet point indentation

### DIFF
--- a/solus_sc/changelog.py
+++ b/solus_sc/changelog.py
@@ -53,6 +53,8 @@ class ScChangelogEntry(Gtk.EventBox):
 
         # Iterate all the lines
         for r in text.split("\n"):
+            # Save number of leading spaces for bullet point indentation
+            lspaces = len(r) - len(r.lstrip())
             r = r.strip()
 
             # Handle Differential IDs by stylizing them
@@ -73,6 +75,10 @@ class ScChangelogEntry(Gtk.EventBox):
             # Check if this is a bullet point
             if (r.startswith("- ") or r.startswith("* ")) and len(r) > 2:
                 r = u' \u2022 ' + r[2:]
+                # add a tab for every indentation level
+                while (lspaces > 0):
+                    r = "\t" + r
+                    lspaces -= 1
 
             for i in r.split(" "):
                 uri = GENERAL_URI.match(i)


### PR DESCRIPTION
Currently the Software Center changelogs make no difference between different indentation levels (unlike our dev tracker), which can make it look a bit disorderly at times.
This PR fixes this by adding a tab for every level of indentation.

**As an example the Gnome Control Center changelog:**

**Before:**
![Screenshot from 2021-01-02 19:08:00](https://user-images.githubusercontent.com/6317346/103463727-d0b09580-4d2e-11eb-9cab-0c4e9703f1f0.png)

**After:**
![Screenshot from 2021-01-02 19:07:38](https://user-images.githubusercontent.com/6317346/103463729-d73f0d00-4d2e-11eb-8927-ae6cba954156.png)

