### PR TITLE
Deprecate dcadec

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -857,5 +857,8 @@
 		<Package>ruby-yard</Package>
 		<Package>rubyzip</Package>
 		<Package>rubyntlm</Package>
+		<Package>dcadec</Package>
+		<Package>dcadec-devel</Package>
+		<Package>dcadec-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1176,5 +1176,10 @@
 		<Package>ruby-yard</Package>
 		<Package>rubyzip</Package>
 		<Package>rubyntlm</Package>
+
+		<!-- Was merged into ffmpeg, currently nothing uses it -->
+		<Package>dcadec</Package>
+		<Package>dcadec-devel</Package>
+		<Package>dcadec-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Deprecate dcadec as nothing uses it and this project was [merged into FFmpeg in 2016](https://github.com/foo86/dcadec/blob/master/README.md).