### PR TITLE
Deprecate python-subprocess32 and pygtksourceview

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -736,6 +736,10 @@
 		<Package>python-backports.unittest_mock</Package>
 		<Package>python-backports.ssl_match_hostname</Package>
 		<Package>python-base58</Package>
+		<Package>python-subprocess32</Package>
+		<Package>python-subprocess32-dbginfo</Package>
+		<Package>pygtksourceview</Package>
+		<Package>pygtksourceview-devel</Package>
 		<Package>elementary-icon-theme</Package>
 		<Package>riot</Package>
 		<Package>riot-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1022,6 +1022,10 @@
 		<Package>python-backports.unittest_mock</Package>
 		<Package>python-backports.ssl_match_hostname</Package>
 		<Package>python-base58</Package>
+		<Package>python-subprocess32</Package>
+		<Package>python-subprocess32-dbginfo</Package>
+		<Package>pygtksourceview</Package>
+		<Package>pygtksourceview-devel</Package>
 
 		<Package>elementary-icon-theme</Package>
 


### PR DESCRIPTION
`pygtksourceview` was a dependency for `cherrytree` but now it doesn't need it.
`python-subprocess32` was a dependency for `matplotlib` which now is built with python3.