### PR TITLE
Deprecate libkate-docs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -863,5 +863,6 @@
 		<Package>exfat-utils</Package>
 		<Package>albert</Package>
 		<Package>albert-dbginfo</Package>
+		<Package>libkate-docs</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1186,9 +1186,12 @@
 
 		<!-- replaced by exfatprogs //-->
 		<Package>exfat-utils</Package>
-		
+
 		<!-- Licensing dispute upstream per https://github.com/albertlauncher/albert/issues/765 //-->
 		<Package>albert</Package>
 		<Package>albert-dbginfo</Package>
+
+		<!-- libkate cleanup -->
+		<Package>libkate-docs</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Deprecate libkate-docs.

Reference: https://dev.getsol.us/D10659