### PR TITLE
Deprecate beignet

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -871,5 +871,6 @@
 		<Package>systemsettings-devel</Package>
 		<Package>snapd-glib-docs</Package>
 		<Package>antimicrox-devel</Package>
+		<Package>beignet</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -872,5 +872,7 @@
 		<Package>snapd-glib-docs</Package>
 		<Package>antimicrox-devel</Package>
 		<Package>beignet</Package>
+		<Package>beignet-devel</Package>
+		<Package>beignet-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1206,5 +1206,8 @@
 		
 		<!-- Headers no longer shipped -->
 		<Package>antimicrox-devel</Package>
+
+		<!-- Replaced by intel-compute-runtime -->
+		<Package>beignet</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1209,5 +1209,7 @@
 
 		<!-- Replaced by intel-compute-runtime -->
 		<Package>beignet</Package>
+		<Package>beignet-devel</Package>
+		<Package>beignet-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Replaced by `intel-compute-runtime`.