### PR TITLE
Deprecate python-argparse and python-qt5

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -745,6 +745,9 @@
 		<Package>python-subprocess32-dbginfo</Package>
 		<Package>pygtksourceview</Package>
 		<Package>pygtksourceview-devel</Package>
+		<Package>python-argparse</Package>
+		<Package>python-qt5</Package>
+		<Package>python-qt5-dbginfo</Package>
 		<Package>elementary-icon-theme</Package>
 		<Package>riot</Package>
 		<Package>riot-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1031,6 +1031,9 @@
 		<Package>python-subprocess32-dbginfo</Package>
 		<Package>pygtksourceview</Package>
 		<Package>pygtksourceview-devel</Package>
+		<Package>python-argparse</Package>
+		<Package>python-qt5</Package>
+		<Package>python-qt5-dbginfo</Package>
 
 		<Package>elementary-icon-theme</Package>
 


### PR DESCRIPTION
They are both python2 packages.
`python-argparse` initially was a dep for `python-adapt-parser`, but not needed anymore.
About `pygoocanvas` didn't find any package that is using it, or why it was packaged at first place.