### PR TITLE
Deprecate klavaro-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -885,5 +885,6 @@
 		<Package>libgtksourceview-dbginfo</Package>
 		<Package>libgtksourceview-devel</Package>
 		<Package>libgtksourceview-docs</Package>
+		<Package>klavaro-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1226,5 +1226,8 @@
 		<Package>libgtksourceview-dbginfo</Package>
 		<Package>libgtksourceview-devel</Package>
 		<Package>libgtksourceview-docs</Package>
+
+		<!-- gtkdatabox3 is now its own package -->
+		<Package>klavaro-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Think I did this right.

klavaro-devel no longer exists. https://dev.getsol.us/D10867
The old gtkdatabox is no longer shipping as an internal library. https://sourceforge.net/p/klavaro/code/HEAD/tree/trunk/ChangeLog