### PR TITLE
Undeprecate Kotlin

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -618,7 +618,6 @@
 		<Package>desmume-dbginfo</Package>
 		<Package>dukto</Package>
 		<Package>dukto-dbginfo</Package>
-		<Package>kotlin</Package>
 		<Package>mp3diags</Package>
 		<Package>mp3diags-dbginfo</Package>
 		<Package>obmenu</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -857,7 +857,6 @@
 		<Package>desmume-dbginfo</Package>
 		<Package>dukto</Package>
 		<Package>dukto-dbginfo</Package>
-		<Package>kotlin</Package>
 		<Package>mp3diags</Package>
 		<Package>mp3diags-dbginfo</Package>
 		<Package>obmenu</Package>


### PR DESCRIPTION
Now maintainable due to presence of JDK 11 in the repository.