### PR TITLE
Deprecate mozjs38 and python-functools32

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -747,6 +747,7 @@
 		<Package>python-argparse</Package>
 		<Package>python-qt5</Package>
 		<Package>python-qt5-dbginfo</Package>
+		<Package>python-functools32</Package>
 		<Package>elementary-icon-theme</Package>
 		<Package>riot</Package>
 		<Package>riot-dbginfo</Package>
@@ -911,5 +912,8 @@
 		<Package>pygoocanvas-devel</Package>
 		<Package>gnome-shell-extension-dash-to-dock</Package>
 		<Package>gnome-screensaver</Package>
+		<Package>mozjs38</Package>
+		<Package>mozjs38-dbginfo</Package>
+		<Package>mozjs38-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1033,6 +1033,7 @@
 		<Package>python-argparse</Package>
 		<Package>python-qt5</Package>
 		<Package>python-qt5-dbginfo</Package>
+		<Package>python-functools32</Package>
 
 		<Package>elementary-icon-theme</Package>
 
@@ -1260,5 +1261,10 @@
 
 		<!-- Renamed to budgie-screensaver -->
 		<Package>gnome-screensaver</Package>
+
+		<!-- Oad doesn't need it anymore -->
+		<Package>mozjs38</Package>
+		<Package>mozjs38-dbginfo</Package>
+		<Package>mozjs38-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
`python-functools32` orphan python2 package.
`mozjs38` isn't need anymore by [0ad](https://dev.getsol.us/D10988)