### PR TITLE
Undeprecate qt5-docs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -98,7 +98,6 @@
 		<Package>qt5</Package>
 		<Package>qt5-demos</Package>
 		<Package>qt5-devel</Package>
-		<Package>qt5-docs</Package>
 		<Package>mate-notification-theme-solus</Package>
 		<Package>kernel-libc-devel</Package>
 		<Package>kernel-tools</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -112,7 +112,6 @@
 		<Package>qt5</Package>
 		<Package>qt5-demos</Package>
 		<Package>qt5-devel</Package>
-		<Package>qt5-docs</Package>
 
 		<!-- Renamed to -slate //-->
 		<Package>mate-notification-theme-solus</Package>


### PR DESCRIPTION
qt5-docs is being included back into the Solus repository to make Qt Creator show Qt5 examples, so let's undeprecate the package.