### PR TITLE
Deprecation of ilmbase

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -984,5 +984,8 @@
 		<Package>font-firago</Package>
 		<Package>font-ibm-plex</Package>
 		<Package>vte2-docs</Package>
+		<Package>ilmbase</Package>
+		<Package>ilmbase-dbginfo</Package>
+		<Package>ilmbase-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1370,5 +1370,10 @@
 
 		<!-- Old orphan package -->
 		<Package>vte2-docs</Package>
+
+		<!-- Officially deprecated by the ASWF -->
+		<Package>ilmbase</Package>
+		<Package>ilmbase-dbginfo</Package>
+		<Package>ilmbase-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
`ilmbase` was superseeded by [`imath`](https://github.com/AcademySoftwareFoundation/Imath) starting with `openexr` version `3.0.0`.
