### PR TITLE
Drop python2 and merge -devel to python-sip

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -915,6 +915,10 @@
 		<Package>mozjs38</Package>
 		<Package>mozjs38-dbginfo</Package>
 		<Package>mozjs38-devel</Package>
+		<Package>python-sip-devel</Package>
+		<Package>python3-sip</Package>
+		<Package>python3-sip-dbginfo</Package>
+		<Package>python3-sip-devel</Package>
 		<Package>libblocksruntime</Package>
 		<Package>libblocksruntime-devel</Package>
 	</Obsoletes>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1267,6 +1267,12 @@
 		<Package>mozjs38-dbginfo</Package>
 		<Package>mozjs38-devel</Package>
 
+		<!-- Drop python2 and merge -devel to python-sip -->
+		<Package>python-sip-devel</Package>
+		<Package>python3-sip</Package>
+		<Package>python3-sip-dbginfo</Package>
+		<Package>python3-sip-devel</Package>
+
 		<!-- Replaced by libdispatch -->
 		<Package>libblocksruntime</Package>
 		<Package>libblocksruntime-devel</Package>


### PR DESCRIPTION
Per https://dev.getsol.us/D11096 stack.
Made the changes near the end to hopefully avoid conflict with Yako's PR.