### PR TITLE
Fix (download) size unit (KB -> KiB)

### DIFF
--- a/solus_sc/util.py
+++ b/solus_sc/util.py
@@ -21,7 +21,7 @@ def sc_format_size(size):
     for i, label in enumerate(labels):
         if size < 1000 or i == len(labels) - 1:
             return size, label
-        size = float(size / 1000)
+        size = float(size / 1024)
 
 
 def sc_format_size_local(size, double_precision=False):


### PR DESCRIPTION
Currently the Software Center prints binary byte units (KiB, MiB,...) in e.g. the Updates view, but actually calculates "regular" i.e. decimal power units (KB, MB,...)

See this discussion: https://discuss.getsol.us/d/6834-difference-between-software-center-and-terminal-update/19

This PR fixes it so that actually binary byte units are calculated. 

P.S. I've left the cutoff at "size < 1000" because 1023 KiB looks worse than 0.9 MiB in my opinion, but can adjust that if you feel the alternative is better.