### PR TITLE
Deprecate qt5-base-docs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -917,5 +917,6 @@
 		<Package>mozjs38-devel</Package>
 		<Package>libblocksruntime</Package>
 		<Package>libblocksruntime-devel</Package>
+		<Package>qt5-base-docs</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1270,5 +1270,8 @@
 		<!-- Replaced by libdispatch -->
 		<Package>libblocksruntime</Package>
 		<Package>libblocksruntime-devel</Package>
+
+		<!-- We now have a single package for Qt5 doc -->
+		<Package>qt5-base-docs</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
We forgot to deprecate `qt5-base-docs`. This package has no reason to exist anymore since `qt5-doc` includes all the Qt5 documentation.