### PR TITLE
Restoration of liblttng

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -430,8 +430,6 @@
 		<Package>libgestures</Package>
 		<Package>libguess-devel</Package>
 		<Package>libguess</Package>
-		<Package>liblttng-ust-devel</Package>
-		<Package>liblttng-ust</Package>
 		<Package>libpqxx-devel</Package>
 		<Package>libpqxx</Package>
 		<Package>librepo-devel</Package>
@@ -440,8 +438,6 @@
 		<Package>libsolv</Package>
 		<Package>libtrace-devel</Package>
 		<Package>libtrace</Package>
-		<Package>liburcu-devel</Package>
-		<Package>liburcu</Package>
 		<Package>libwandio-devel</Package>
 		<Package>libwandio</Package>
 		<Package>libxfont-32bit-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -590,8 +590,6 @@
 		<Package>libgestures</Package>
 		<Package>libguess-devel</Package>
 		<Package>libguess</Package>
-		<Package>liblttng-ust-devel</Package>
-		<Package>liblttng-ust</Package>
 		<Package>libpqxx-devel</Package>
 		<Package>libpqxx</Package>
 		<Package>librepo-devel</Package>
@@ -600,8 +598,6 @@
 		<Package>libsolv</Package>
 		<Package>libtrace-devel</Package>
 		<Package>libtrace</Package>
-		<Package>liburcu-devel</Package>
-		<Package>liburcu</Package>
 		<Package>libwandio-devel</Package>
 		<Package>libwandio</Package>
 		<Package>libxfont-32bit-devel</Package>


### PR DESCRIPTION
As `dotnet` depends on `lttng-ust` and it was deprecated long ago, the package must be reintroduced.
