### PR TITLE
Deprecate devel packages for cava, scribus and vgrep

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -916,6 +916,9 @@
 		<Package>python3-sip</Package>
 		<Package>python3-sip-dbginfo</Package>
 		<Package>python3-sip-devel</Package>
+		<Package>cava-devel</Package>
+		<Package>scribus-devel</Package>
+		<Package>vgrep-devel</Package>
 		<Package>libblocksruntime</Package>
 		<Package>libblocksruntime-devel</Package>
 		<Package>qt5-base-docs</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1272,6 +1272,11 @@
 		<Package>python3-sip-dbginfo</Package>
 		<Package>python3-sip-devel</Package>
 
+		<!-- No more devel packages -->
+		<Package>cava-devel</Package>
+		<Package>scribus-devel</Package>
+		<Package>vgrep-devel</Package>
+
 		<!-- Replaced by libdispatch -->
 		<Package>libblocksruntime</Package>
 		<Package>libblocksruntime-devel</Package>


### PR DESCRIPTION
cava, scribus and vgrep no longer have devel packages.