### PR TITLE
Restoration of coin3d

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -391,8 +391,6 @@
 		<Package>arc-red-gtk-theme</Package>
 		<Package>chrpath</Package>
 		<Package>clicompanion</Package>
-		<Package>coin3d-devel</Package>
-		<Package>coin3d</Package>
 		<Package>corsaro-devel</Package>
 		<Package>corsaro</Package>
 		<Package>createrepo_c-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -551,8 +551,6 @@
 		<Package>arc-red-gtk-theme</Package>
 		<Package>chrpath</Package>
 		<Package>clicompanion</Package>
-		<Package>coin3d-devel</Package>
-		<Package>coin3d</Package>
 		<Package>corsaro-devel</Package>
 		<Package>corsaro</Package>
 		<Package>createrepo_c-devel</Package>


### PR DESCRIPTION
The `coin3d` package got remove during a major clean-up, but `freecad` depends on it.
