### PR TITLE
Restoration of neovim-qt

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -337,7 +337,6 @@
 		<Package>mysql-connector-cpp</Package>
 		<Package>mysql-connector-cpp-dbginfo</Package>
 		<Package>mysql-connector-cpp-devel</Package>
-		<Package>neovim-qt</Package>
 		<Package>newsbeuter</Package>
 		<Package>openbazaar</Package>
 		<Package>openbazaard</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -491,7 +491,6 @@
 		<Package>mysql-connector-cpp</Package>
 		<Package>mysql-connector-cpp-dbginfo</Package>
 		<Package>mysql-connector-cpp-devel</Package>
-		<Package>neovim-qt</Package>
 		<Package>newsbeuter</Package>
 		<Package>openbazaar</Package>
 		<Package>openbazaard</Package>


### PR DESCRIPTION
Because @EbonJaeger took maintainership of `neovim-qt` and it wasn't restored in SC, this PR fixes the issue.
