### PR TITLE
Deprecate

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -987,5 +987,7 @@
 		<Package>ilmbase</Package>
 		<Package>ilmbase-dbginfo</Package>
 		<Package>ilmbase-devel</Package>
+		<Package>webvfx</Package>
+		<Package>akregator-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1375,5 +1375,9 @@
 		<Package>ilmbase</Package>
 		<Package>ilmbase-dbginfo</Package>
 		<Package>ilmbase-devel</Package>
+
+		<!-- mlt and apps update -->
+		<Package>webvfx</Package>
+		<Package>akregator-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
- webvfx deprecated by upstream
- devel package is not needed anymore