### PR TITLE
Third Party: Update sublime text package name and URLs to new scheme

### DIFF
--- a/eopkg_assist/backend.py
+++ b/eopkg_assist/backend.py
@@ -77,8 +77,8 @@ APPS = {
         "network/im/slack-desktop/pspec.xml",
     "spotify":
         "multimedia/music/spotify/pspec.xml",
-    "sublime-text-3":
-        "programming/sublime-text-3/pspec.xml",
+    "sublime-text":
+        "programming/sublime-text/pspec.xml",
     "viber":
         "network/im/viber/pspec.xml",
     "webstorm":

--- a/solus_sc/thirdparty.py
+++ b/solus_sc/thirdparty.py
@@ -107,11 +107,11 @@ APPS = {
         ('Spotify', 'spotify',
          'Spotify Music, Video and Podcast Streaming Client.',
          'multimedia/music/spotify/pspec.xml'),
-    'sublime-text-3':
+    'sublime-text':
         ('Sublime Text', 'sublime-text',
          'Sublime Text is a sophisticated text editor for code, markup and '
          'prose.',
-         'programming/sublime-text-3/pspec.xml'),
+         'programming/sublime-text/pspec.xml'),
     'viber':
         ('Viber', 'viber',
          'An instant messaging and VoIP app for various mobile operating '


### PR DESCRIPTION
This updates the name and URLs for the (Third Party) sublime text package to conform to the corresponding restructure in the Third Party repository: https://github.com/getsolus/3rd-party/pull/55

This will have to be committed/pushed at the same time as the Third Party repo PR to avoid confusion due to error messages on user's systems.

See also the change for help-center-docs: https://github.com/getsolus/help-center-docs/pull/294