### PR TITLE
Re-inclusion of yad for steamtinkerlaunch

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -373,9 +373,6 @@
 		<Package>webtorrent-desktop-dbginfo</Package>
 		<Package>vagrant</Package>
 		<Package>vault</Package>
-		<Package>yad</Package>
-		<Package>yad-dbginfo</Package>
-		<Package>yad-devel</Package>
 		<Package>yakyak</Package>
 		<Package>yakyak-dbginfo</Package>
 		<Package>libnfsidmap</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -527,9 +527,6 @@
 		<Package>webtorrent-desktop-dbginfo</Package>
 		<Package>vagrant</Package>
 		<Package>vault</Package>
-		<Package>yad</Package>
-		<Package>yad-dbginfo</Package>
-		<Package>yad-devel</Package>
 		<Package>yakyak</Package>
 		<Package>yakyak-dbginfo</Package>
 


### PR DESCRIPTION
Re-include yad into the repository. Necessary for steamtinkerlaunch. See https://dev.getsol.us/T9674

Diff for yad and steamtinkerlaunch on phab incoming.

My package doesn't create a yad-dbginfo, so I left that one out.