### PR TITLE
Deprecate ijs and libuser

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -999,6 +999,11 @@
 		<Package>libindicator-32bit-devel</Package>
 		<Package>indicator-application</Package>
 		<Package>indicator-application-dbginfo</Package>
+		<Package>ijs</Package>
+		<Package>ijs-devel</Package>
+		<Package>libuser</Package>
+		<Package>libuser-dbginfo</Package>
+		<Package>libuser-devel</Package>
 		<Package>keepassx</Package>
 		<Package>keepassx-dbginfo</Package>
 		<Package>webvfx</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1392,6 +1392,15 @@
 		<Package>indicator-application</Package>
 		<Package>indicator-application-dbginfo</Package>
 
+		<!-- ijs has been merged into ghostscript -->
+		<Package>ijs</Package>
+		<Package>ijs-devel</Package>
+
+		<!-- Dependency of deprecated package "usermode" -->
+		<Package>libuser</Package>
+		<Package>libuser-dbginfo</Package>
+		<Package>libuser-devel</Package>
+
 		<!-- Renamed to keepassxc -->
 		<Package>keepassx</Package>
 		<Package>keepassx-dbginfo</Package>


### PR DESCRIPTION
This package is no longer needed. Checked all the repository and none of the existing packages needs it.
Reference https://dev.getsol.us/D10692