### PR TITLE
Deprecate residualvm

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1010,5 +1010,7 @@
 		<Package>kodi-platform</Package>
 		<Package>kodi-platform-devel</Package>
 		<Package>kodi-platform-dbginfo</Package>
+		<Package>residualvm</Package>
+		<Package>residualvm-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1410,5 +1410,9 @@
 		<Package>kodi-platform</Package>
 		<Package>kodi-platform-devel</Package>
 		<Package>kodi-platform-dbginfo</Package>
+
+		<!-- ResidualVM was merged into ScummVM project as of ScummVM 2.5.0 -->
+		<Package>residualvm</Package>
+		<Package>residualvm-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
ResidualVM was merged into ScummVM as of 2.5.0, and "standalone" RVM is no longer maintained.