### PR TITLE
Deprecate gourmet

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1018,5 +1018,6 @@
 		<Package>residualvm</Package>
 		<Package>residualvm-dbginfo</Package>
 		<Package>cppzmq-devel</Package>
+		<Package>gourmet</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1426,5 +1426,8 @@
 
 		<!-- cppzmq is a headers-only package and everything from cppzqm-devel was moved into the main package -->
 		<Package>cppzmq-devel</Package>
+
+		<! -- unmaintained py2-gtk2 package blocking python-pillow update that is affected by multiple CVEs. The py3 fork gourmand can be requested via normal inclusion process. -->
+		<Package>gourmet</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
An unmaintained py2-gtk2 based package that is blocking our python-pillow update.
Our current python-pillow version is affected by multiple CVEs

The py3 fork gourmand can be requested via normal inclusion process.

See T10003.