### PR TITLE
Replace youtube-dl with yt-dlp

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1019,5 +1019,6 @@
 		<Package>residualvm-dbginfo</Package>
 		<Package>cppzmq-devel</Package>
 		<Package>gourmet</Package>
+		<Package>youtube-dl</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -387,9 +387,6 @@
 		<!-- No longer feasible to package and ship without enforcing itch-setup and auto-updates //-->
 		<Package>itch</Package>
 		<Package>itch-dbginfo</Package>
-		
-		<!-- yt-dlc was temporarily used as fork of youtube-dl //-->
-		<Package>yt-dlc</Package>
 
 		<!-- No longer maintained by upstreams //-->
 		<Package>adapta-kde</Package>
@@ -1429,5 +1426,9 @@
 
 		<! -- unmaintained py2-gtk2 package blocking python-pillow update that is affected by multiple CVEs. The py3 fork gourmand can be requested via normal inclusion process. -->
 		<Package>gourmet</Package>
+
+		<!-- Both youtube-dl and yt-dlc were replaced by the more active yt-dlp fork //-->
+		<Package>youtube-dl</Package>
+		<Package>yt-dlc</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Replace youtube-dl with yt-dlp

See https://dev.getsol.us/T10001

Corresponding diff on phab: https://dev.getsol.us/D12196