### PR TITLE
Rename ovmf package to edk2-ovmf

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1025,5 +1025,6 @@
 		<Package>qt6-location-demos</Package>
 		<Package>qt6-location-devel</Package>
 		<Package>python-getkey</Package>
+		<Package>ovmf</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1450,5 +1450,8 @@
 
 		<!-- paperwork-shell dropped this package -->
 		<Package>python-getkey</Package>
+		
+		<!-- ovmf package has been renamed to edk2-ovmf -->
+		<Package>ovmf</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Looks like the last two people to add to this didn't actually run merged_repos.sh and instead manually modified distribution.xml. Otherwise they would have noticed that the distribution.xml.in was invalid xml...