### PR TITLE
Deprecate python-pdfrw

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1019,6 +1019,7 @@
 		<Package>residualvm-dbginfo</Package>
 		<Package>cppzmq-devel</Package>
 		<Package>gourmet</Package>
+		<Package>python-pdfrw</Package>
 		<Package>youtube-dl</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1427,6 +1427,9 @@
 		<! -- unmaintained py2-gtk2 package blocking python-pillow update that is affected by multiple CVEs. The py3 fork gourmand can be requested via normal inclusion process. -->
 		<Package>gourmet</Package>
 
+		<!-- ex dependency of img2pdf -->
+		<Package>python-pdfrw</Package>
+
 		<!-- Both youtube-dl and yt-dlc were replaced by the more active yt-dlp fork //-->
 		<Package>youtube-dl</Package>
 		<Package>yt-dlc</Package>


### PR DESCRIPTION
`img2pdf` removed `python-pdfrw` from tests and going forward using `python-pikepdf`.
There is no new release for `pdfrw` since 18 Sep 2017.