### PR TITLE
Deprecate python-apscheduler and python-rawkit

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1019,6 +1019,8 @@
 		<Package>cppzmq-devel</Package>
 		<Package>gourmet</Package>
 		<Package>python-pdfrw</Package>
+		<Package>python-apscheduler</Package>
+		<Package>python-rawkit</Package>
 		<Package>youtube-dl</Package>
 		<Package>yt-dlc</Package>
 		<Package>lbry-desktop</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1430,6 +1430,12 @@
 		<!-- ex dependency of img2pdf -->
 		<Package>python-pdfrw</Package>
 
+		<!-- vorta removed APScheduler dependency and is using QTimer directly -->
+		<Package>python-apscheduler</Package>
+
+		<!-- Not needed anymore by rapid-photo-downloader -->
+		<Package>python-rawkit</Package>
+
 		<!-- Both youtube-dl and yt-dlc were replaced by the more active yt-dlp fork -->
 		<Package>youtube-dl</Package>
 		<Package>yt-dlc</Package>


### PR DESCRIPTION
Reference diffs:
python-rawkit: https://dev.getsol.us/D12475
python-apscheduler: https://dev.getsol.us/R4728:4535f790223b