### PR TITLE
Deprecate ruby_dep

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1029,5 +1029,7 @@
 		<Package>qt6-location-dbginfo</Package>
 		<Package>qt6-location-demos</Package>
 		<Package>qt6-location-devel</Package>
+		<Package>ruby_dep</Package>
+		<Package>ruby-mustache</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1030,6 +1030,5 @@
 		<Package>qt6-location-demos</Package>
 		<Package>qt6-location-devel</Package>
 		<Package>ruby_dep</Package>
-		<Package>ruby-mustache</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1451,8 +1451,7 @@
 		<Package>qt6-location-demos</Package>
 		<Package>qt6-location-devel</Package>
 
-		<!-- Unused gems since ruby 3 stack upgrade -->
+		<!-- Unused gem since ruby 3 stack upgrade -->
 		<Package>ruby_dep</Package>
-		<Package>ruby-mustache</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1453,6 +1453,5 @@
 
 		<!-- paperwork-shell dropped this package -->
 		<Package>python-getkey</Package>
-
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1450,5 +1450,9 @@
 		<Package>qt6-location-dbginfo</Package>
 		<Package>qt6-location-demos</Package>
 		<Package>qt6-location-devel</Package>
+
+		<!-- Unused gems since ruby 3 stack upgrade -->
+		<Package>ruby_dep</Package>
+		<Package>ruby-mustache</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
https://dev.getsol.us/D12586

During the ruby 3 stack upgrade `ruby-listen` was upgraded meaning `ruby_dep` ([which is abandoned](https://github.com/e2/ruby_dep/issues/39)) is no longer depended on by anything.