### PR TITLE
Deprecate python-cssutils and python-pypeg2

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1025,6 +1025,8 @@
 		<Package>yt-dlc</Package>
 		<Package>lbry-desktop</Package>
 		<Package>lbry-desktop-dbginfo</Package>
+		<Package>python-cssutils</Package>
+		<Package>python-pypeg2</Package>
 		<Package>qt6-location</Package>
 		<Package>qt6-location-dbginfo</Package>
 		<Package>qt6-location-demos</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1445,6 +1445,10 @@
 		<Package>lbry-desktop</Package>
 		<Package>lbry-desktop-dbginfo</Package>
 
+		<!-- Not needed anymore by qutebrowser -->
+		<Package>python-cssutils</Package>
+		<Package>python-pypeg2</Package>
+
 		<!-- Upstream dropped this package -->
 		<Package>qt6-location</Package>
 		<Package>qt6-location-dbginfo</Package>


### PR DESCRIPTION
These dependencies were removed by `qutebrowser` in this patch https://dev.getsol.us/D10453.
Currently they aren't being used by any other package.