### PR TITLE
Deprecate python-getkey because paperwork-shell dropped it

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1029,5 +1029,6 @@
 		<Package>qt6-location-dbginfo</Package>
 		<Package>qt6-location-demos</Package>
 		<Package>qt6-location-devel</Package>
+		<Package>python-getkey</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1450,5 +1450,8 @@
 		<Package>qt6-location-dbginfo</Package>
 		<Package>qt6-location-demos</Package>
 		<Package>qt6-location-devel</Package>
+
+		<!-- paperwork-shell dropped this package -->
+		<Package>python-getkey</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
See https://dev.getsol.us/D12704#215747