### PR TITLE
Undeprecate python-qrcode (D12764)

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -928,7 +928,6 @@
 		<Package>python-ecdsa</Package>
 		<Package>python-jsonrpclib</Package>
 		<Package>python-pbkdf2</Package>
-		<Package>python-qrcode</Package>
 		<Package>python-slowaes</Package>
 		<Package>python-xmlrpclib</Package>
 		<Package>peercoin</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1290,7 +1290,6 @@
 		<Package>python-ecdsa</Package>
 		<Package>python-jsonrpclib</Package>
 		<Package>python-pbkdf2</Package>
-		<Package>python-qrcode</Package>
 		<Package>python-slowaes</Package>
 		<Package>python-xmlrpclib</Package>
 		<Package>peercoin</Package>


### PR DESCRIPTION
Is a new dependency for onionshare: https://dev.getsol.us/D12764