### PR TITLE
Undeprecate tagainijisho now that it supports Qt5

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -956,8 +956,6 @@
 		<Package>qt4-devel</Package>
 		<Package>shiboken</Package>
 		<Package>shiboken-dbginfo</Package>
-		<Package>tagainijisho</Package>		
-		<Package>tagainijisho-devel</Package>
 		<Package>cgmanager</Package>
 		<Package>cgmanager-dbginfo</Package>
 		<Package>cgmanager-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1322,8 +1322,6 @@
 		<Package>qt4-devel</Package>
 		<Package>shiboken</Package>
 		<Package>shiboken-dbginfo</Package>
-		<Package>tagainijisho</Package>		
-		<Package>tagainijisho-devel</Package>
 		
 		<!-- Deprecated upstream -->
 		<Package>cgmanager</Package>


### PR DESCRIPTION
Undeprecate tagainijisho now that it supports Qt5 and has been re-accepted into the repository.

See https://dev.getsol.us/T10152