### PR TITLE
Deprecate arc-plank-theme

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1026,5 +1026,6 @@
 		<Package>qt6-location-devel</Package>
 		<Package>python-getkey</Package>
 		<Package>ovmf</Package>
+		<Package>arc-plank-theme</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1450,8 +1450,11 @@
 
 		<!-- paperwork-shell dropped this package -->
 		<Package>python-getkey</Package>
-		
+
 		<!-- ovmf package has been renamed to edk2-ovmf -->
 		<Package>ovmf</Package>
+
+		<!-- Merged into arc-gtk-theme -->
+		<Package>arc-plank-theme</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Is now included in the `arc-gtk-theme` package since this has been merged:

https://dev.getsol.us/D12929