### PR TITLE
Remove gmime26

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1026,5 +1026,9 @@
 		<Package>qt6-location-devel</Package>
 		<Package>python-getkey</Package>
 		<Package>ovmf</Package>
+		<Package>gmime26</Package>
+		<Package>gmime26-docs</Package>
+		<Package>gmime26-devel</Package>
+		<Package>gmime26-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1453,5 +1453,11 @@
 		
 		<!-- ovmf package has been renamed to edk2-ovmf -->
 		<Package>ovmf</Package>
+
+		<!-- geary no longer needs this -->
+		<Package>gmime26</Package>
+		<Package>gmime26-docs</Package>
+		<Package>gmime26-devel</Package>
+		<Package>gmime26-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Relates to https://dev.getsol.us/D12984

Geary now uses gmime 3.x and we no longer need gmime 2.6 related packages