### PR TITLE
Deprecate libgit2solbuild

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1026,5 +1026,8 @@
 		<Package>qt6-location-devel</Package>
 		<Package>python-getkey</Package>
 		<Package>ovmf</Package>
+		<Package>libgit2solbuild</Package>
+		<Package>libgit2solbuild-dbginfo</Package>
+		<Package>libgit2solbuild-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1453,5 +1453,10 @@
 		
 		<!-- ovmf package has been renamed to edk2-ovmf -->
 		<Package>ovmf</Package>
+
+		<!-- Temporary package which helped handle libgit2 rebuilds -->
+		<Package>libgit2solbuild</Package>
+		<Package>libgit2solbuild-dbginfo</Package>
+		<Package>libgit2solbuild-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
This was a temporary package for solbuild to link against so it could safely handle libgit2 rebuilds. Classic chicken and egg dependency problem.