### PR TITLE
Deprecate irrlicht

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1052,5 +1052,8 @@
 		<Package>opencascade-ce</Package>
 		<Package>opencascade-dbginfo</Package>
 		<Package>opencascade-devel</Package>
+		<Package>irrlicht</Package>
+		<Package>irrlicht-devel</Package>
+		<Package>irrlicht-dbginfo</Package>	
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1499,5 +1499,10 @@
 		<Package>opencascade-ce</Package>
 		<Package>opencascade-dbginfo</Package>
 		<Package>opencascade-devel</Package>
+
+		<!-- Replaced by irrlichtmt -->
+		<Package>irrlicht</Package>
+		<Package>irrlicht-devel</Package>
+		<Package>irrlicht-dbginfo</Package>	
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Minetest switched to their own fork, and Irrlicht wasn't used by anything else in the repo.