### PR TITLE
Fix opencascade-ce deprecation

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1085,15 +1085,15 @@
 		<Package>libuninameslist-dbginfo</Package>
 		<Package>libuninameslist-devel</Package>
 		<Package>opencascade-ce</Package>
-		<Package>opencascade-dbginfo</Package>
-		<Package>opencascade-devel</Package>
+		<Package>opencascade-ce-dbginfo</Package>
+		<Package>opencascade-ce-devel</Package>
 		<Package>irrlicht</Package>
 		<Package>irrlicht-devel</Package>
 		<Package>irrlicht-dbginfo</Package>
 		<Package>mlt6</Package>
 		<Package>mlt6-devel</Package>
 		<Package>mlt6-dbginfo</Package>
-    <Package>mlt6-python</Package>
+		<Package>mlt6-python</Package>
 		<Package>python-cached-property</Package>
 		<Package>python-docker-py</Package>
 		<Package>python-docker-pycred</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1534,13 +1534,13 @@
 
 		<!--  Use a more up to date mirror instead of the fork -->
 		<Package>opencascade-ce</Package>
-		<Package>opencascade-dbginfo</Package>
-		<Package>opencascade-devel</Package>
+		<Package>opencascade-ce-dbginfo</Package>
+		<Package>opencascade-ce-devel</Package>
 
 		<!-- Replaced by irrlichtmt -->
 		<Package>irrlicht</Package>
 		<Package>irrlicht-devel</Package>
-		<Package>irrlicht-dbginfo</Package>	
+		<Package>irrlicht-dbginfo</Package>
 
 		<!-- mlt 6.x is no longer used -->
 		<Package>mlt6</Package>


### PR DESCRIPTION
Due to a typo we accidentally deprecated the new opencascade `-devel` and `-dbginfo` packages instead of the old ones.

This fixes that (plus some automatic formatting corrections)

Discovered when trying to build `kicad`