### PR TITLE
Deprecate db4.8 and goffice0.8

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1099,5 +1099,11 @@
 		<Package>python-docker-pycred</Package>
 		<Package>python-dockerpty</Package>
 		<Package>python-dotenv</Package>
+		<Package>goffice0.8</Package>
+		<Package>goffice0.8-dbginfo</Package>
+		<Package>goffice0.8-devel</Package>
+		<Package>db4.8</Package>
+		<Package>db4.8-dbginfo</Package>
+		<Package>db4.8-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1554,5 +1554,13 @@
 		<Package>python-docker-pycred</Package>
 		<Package>python-dockerpty</Package>
 		<Package>python-dotenv</Package>
+
+		<!-- no longer needed -->
+		<Package>goffice0.8</Package>
+		<Package>goffice0.8-dbginfo</Package>
+		<Package>goffice0.8-devel</Package>
+		<Package>db4.8</Package>
+		<Package>db4.8-dbginfo</Package>
+		<Package>db4.8-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
These packages no longer are used and they don't build.