### PR TITLE
Deprecate packagekit-docs as well

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -127,6 +127,7 @@
 		<Package>packagekit</Package>
 		<Package>packagekit-devel</Package>
 		<Package>packagekit-dbginfo</Package>
+		<Package>packagekit-docs</Package>
 		<Package>poppler-docs</Package>
 		<Package>poppler-qt4</Package>
 		<Package>poppler-qt4-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -177,6 +177,7 @@
 		<Package>packagekit</Package>
 		<Package>packagekit-devel</Package>
 		<Package>packagekit-dbginfo</Package>
+		<Package>packagekit-docs</Package>
 		<Package>poppler-docs</Package>
 		<Package>poppler-qt4</Package>
 		<Package>poppler-qt4-devel</Package>


### PR DESCRIPTION
It was left over.