### PR TITLE
Deprecate JavaFX 8

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1133,5 +1133,7 @@
 		<Package>lrzip-devel</Package>
 		<Package>gnomint</Package>
 		<Package>gnomint-dbginfo</Package>
+		<Package>openjfx-8</Package>
+		<Package>openjfx-8-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1602,5 +1602,9 @@
 		<!-- unmaintained and doesn't build -->
 		<Package>gnomint</Package>
 		<Package>gnomint-dbginfo</Package>
+
+		<!-- JavaFX 8: ancient and unused -->
+		<Package>openjfx-8</Package>
+		<Package>openjfx-8-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Following https://dev.getsol.us/D13127, `openjfx-8` is not required by anything and this is extremely unlikely to change. It also doesn't build anymore.

Related: https://dev.getsol.us/T10227
Related: https://dev.getsol.us/T9089