### PR TITLE
Deprecate kdev-python

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1144,5 +1144,7 @@
 		<Package>colord-gtk-devel</Package>
 		<Package>openjfx-8</Package>
 		<Package>openjfx-8-dbginfo</Package>
+		<Package>kdev-python</Package>
+		<Package>kdev-python-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1621,5 +1621,10 @@
 		<!-- JavaFX 8: ancient and unused -->
 		<Package>openjfx-8</Package>
 		<Package>openjfx-8-dbginfo</Package>
+
+		<!-- Didn't support python 3.10 at the time. -->
+		<!-- Can be requested for inclusion again once it does. -->
+		<Package>kdev-python</Package>
+		<Package>kdev-python-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Didn't support python 3.10 at the time of stack upgrade. Can be requested for re-inclusion again once it does.