### PR TITLE
Deprecate wxwidgets2.8

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1146,5 +1146,9 @@
 		<Package>openjfx-8-dbginfo</Package>
 		<Package>kdev-python</Package>
 		<Package>kdev-python-dbginfo</Package>
+		<Package>wxwidgets2.8</Package>
+		<Package>wxwidgets2.8-dbginfo</Package>
+		<Package>wxwidgets2.8-devel</Package>
+		<Package>perl-alien-wxwidgets</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1626,5 +1626,12 @@
 		<!-- Can be requested for inclusion again once it does. -->
 		<Package>kdev-python</Package>
 		<Package>kdev-python-dbginfo</Package>
+
+		<!-- wxwidgets2.8 cleanup -->
+		<Package>wxwidgets2.8</Package>
+		<Package>wxwidgets2.8-dbginfo</Package>
+		<Package>wxwidgets2.8-devel</Package>
+		<Package>perl-alien-wxwidgets</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
 Deprecate wxwidgets2.8

No longer needed by anything, last users were:
amule : switched to wxwidgets 3.0
perl-alien-wxwidgets : Using 2.8 config instead of 3.0? Unused and unmaintained regardless.