### PR TITLE
Undeprecate Google Python API package for Deja-Dup

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1047,7 +1047,6 @@
 		<Package>libzhuyin</Package>
 		<Package>libzhuyin-devel</Package>
 		<Package>libzhuyin-dbginfo</Package>
-		<Package>google-api-python-client</Package>
 		<Package>mycroft-core</Package>
 		<Package>pyalsaaudio</Package>
 		<Package>pyalsaaudio-dbginfo</Package>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1056,7 +1056,6 @@
 		<Package>python-fann2-dbginfo</Package>
 		<Package>python-gitdb2</Package>
 		<Package>python-gitpython</Package>
-		<Package>python-google-auth-httplib2</Package>
 		<Package>python-gtts</Package>
 		<Package>python-gtts-token</Package>
 		<Package>python-lazy</Package>
@@ -1076,7 +1075,6 @@
 		<Package>python-smmap2</Package>
 		<Package>python-speech-recognition</Package>
 		<Package>python-speech-recognition-dbginfo</Package>
-		<Package>python-uritemplate</Package>
 		<Package>python-vlc</Package>
 		<Package>python-xmlrunner</Package>
 		<Package>python-xxhash</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1501,7 +1501,6 @@
 		<Package>python-fann2-dbginfo</Package>
 		<Package>python-gitdb2</Package>
 		<Package>python-gitpython</Package>
-		<Package>python-google-auth-httplib2</Package>
 		<Package>python-gtts</Package>
 		<Package>python-gtts-token</Package>
 		<Package>python-lazy</Package>
@@ -1521,7 +1520,6 @@
 		<Package>python-smmap2</Package>
 		<Package>python-speech-recognition</Package>
 		<Package>python-speech-recognition-dbginfo</Package>
-		<Package>python-uritemplate</Package>
 		<Package>python-vlc</Package>
 		<Package>python-xmlrunner</Package>
 		<Package>python-xxhash</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1492,7 +1492,6 @@
 		<Package>libzhuyin-dbginfo</Package>
 
 		<!-- Mycroft never worked correctly -->
-		<Package>google-api-python-client</Package>
 		<Package>mycroft-core</Package>
 		<Package>pyalsaaudio</Package>
 		<Package>pyalsaaudio-dbginfo</Package>


### PR DESCRIPTION
Needed again for newer Deja-Dup.