### PR TITLE
Deprecate eigen2

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1143,6 +1143,7 @@
 		<Package>openjfx-8-dbginfo</Package>
 		<Package>kdev-python</Package>
 		<Package>kdev-python-dbginfo</Package>
+		<Package>eigen2</Package>
 		<Package>wxwidgets2.8</Package>
 		<Package>wxwidgets2.8-dbginfo</Package>
 		<Package>wxwidgets2.8-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1624,6 +1624,9 @@
 		<Package>kdev-python</Package>
 		<Package>kdev-python-dbginfo</Package>
 
+		<!-- Not being used by anything. opencv moved to eigen3 -->
+		<Package>eigen2</Package>
+
 		<!-- wxwidgets2.8 cleanup -->
 		<Package>wxwidgets2.8</Package>
 		<Package>wxwidgets2.8-dbginfo</Package>


### PR DESCRIPTION
Used to be a dependency for `opencv` https://dev.getsol.us/R2235:b8fe74a272fe6b35ce0e10418618d1f319018759