### PR TITLE
Remove Google Talk plugin

### DIFF
--- a/solus_sc/thirdparty.py
+++ b/solus_sc/thirdparty.py
@@ -42,10 +42,6 @@ APPS = {
         ('Google Earth', 'google-earth',
          '3D interface for satellite imagery from Google',
          'network/web/google-earth/pspec.xml'),
-    'google-talkplugin':
-        ('Google Talk Plugin', 'im-google-talk',
-         'The Google Talk plugin for hangouts video and audio',
-         'network/im/google-talkplugin/pspec.xml'),
     'gitkraken':
         ('GitKraken', 'gitkraken',
          'The downright luxurious Git client, for Windows, Mac and Linux',


### PR DESCRIPTION
Google has ended support, see https://support.google.com/talk/?hl=en

Corresponding PR in 3rd-party: https://github.com/getsolus/3rd-party/pull/66

Corresponding PR in help-center-docs: https://github.com/getsolus/help-center-docs/pull/312