### PR TITLE
Undeprecate lapack

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -92,8 +92,6 @@
 		<Package>haste-applet</Package>
 		<Package>screenshot-applet</Package>
 		<Package>vscode-ms</Package>
-		<Package>lapack</Package>
-		<Package>lapack-devel</Package>
 		<Package>mlocate</Package>
 		<Package>qt5</Package>
 		<Package>qt5-demos</Package>


### PR DESCRIPTION
See [D13297](https://dev.getsol.us/D13297) and [T10209](https://dev.getsol.us/T10209).

This can be merged after [D13305](https://dev.getsol.us/D13305) is accepted.