### PR TITLE
Undeprecate dash-to-dock

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -898,7 +898,6 @@
 		<Package>pygoocanvas-dbginfo</Package>
 		<Package>pygoocanvas-devel</Package>
 		<Package>gnome-desktop-branding</Package>
-		<Package>gnome-shell-extension-dash-to-dock</Package>
 		<Package>gnome-screensaver</Package>
 		<Package>mozjs38</Package>
 		<Package>mozjs38-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1240,9 +1240,6 @@
 		<!-- Old branding package -->
 		<Package>gnome-desktop-branding</Package>
 
-		<!-- Temporary Deprecation Until Updated Upstream -->
-		<Package>gnome-shell-extension-dash-to-dock</Package>
-
 		<!-- Renamed to budgie-screensaver -->
 		<Package>gnome-screensaver</Package>
 


### PR DESCRIPTION
Works again after the update to version 72

https://dev.getsol.us/R995:a9f90dc60ea6fe989009eb6649d7153778fb902e