### PR TITLE
Deprecate go-ipfs because of rename to kubo

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1159,5 +1159,7 @@
 		<Package>kwayland-server</Package>
 		<Package>kwayland-server-devel</Package>
 		<Package>kwayland-server-dbginfo</Package>
+		<Package>go-ipfs</Package>
+		<Package>go-ipfs-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1645,5 +1645,9 @@
 		<Package>kwayland-server</Package>
 		<Package>kwayland-server-devel</Package>
 		<Package>kwayland-server-dbginfo</Package>
+
+		<!-- Renamed from go-ipfs to kubo -->
+		<Package>go-ipfs</Package>
+		<Package>go-ipfs-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
See [D13389](https://dev.getsol.us/D13389).