### PR TITLE
Deprecate budgie-control-center-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1167,5 +1167,6 @@
 		<Package>python-genshi</Package>
 		<Package>python-genshi-dbginfo</Package>
 		<Package>python-poyo</Package>
+		<Package>budgie-control-center-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1663,5 +1663,8 @@
 
 		<!-- Not needed anymore by python-cookiecutter -->
 		<Package>python-poyo</Package>
+
+		<!-- File was removed from upstream -->
+		<Package>budgie-control-center-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
The file that was being split into this package has been removed upstream.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>