### PR TITLE
Fix "IRC clients" icon now that HexChat icon changed

### DIFF
--- a/solus_sc/components.py
+++ b/solus_sc/components.py
@@ -45,7 +45,7 @@ ICON_MAPS = {
     "network.download": "transmission",
     "network.email": "internet-mail",
     "network.im": "empathy",
-    "network.irc": "hexchat",
+    "network.irc": "polari",
     "network.news": "internet-news-reader",
     "network.web": "internet-web-browser",
     "network.web.browser": "firefox",


### PR DESCRIPTION
Papirus added a HexChat icon that doesn't serve well as a general IRC icon. So simply switch to the "Polari" icon instead, which more or less maintains the old look.

Old:
![Screenshot from 2022-08-09 09:50:05](https://user-images.githubusercontent.com/6317346/183724296-e99e02f1-2e0e-4ff5-bb2b-8122da31adc4.png)



New Hexchat icon:
![Screenshot from 2022-08-09 10:11:22](https://user-images.githubusercontent.com/6317346/183724330-f790f7a9-59ff-42b0-b04a-382c8cd76d7d.png)

New with Polari icon:
![Screenshot from 2022-08-09 10:11:36](https://user-images.githubusercontent.com/6317346/183724366-aa70a918-580b-4a15-be05-300829a94060.png)

Note: There are a couple of other things one could improve in this part of the Software Center, but this is just a quick fix to get it to the same quality level as before :grin: 

 