### PR TITLE
Undeprecate python-deprecation

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -345,7 +345,6 @@
 		<Package>profanity-devel</Package>
 		<Package>pithos</Package>
 		<Package>python-alembic</Package>
-		<Package>python-deprecation</Package>
 		<Package>python-node-semver</Package>
 		<Package>python-patch</Package>
 		<Package>python-pluginbase</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -495,7 +495,6 @@
 		<Package>profanity-devel</Package>
 		<Package>pithos</Package>
 		<Package>python-alembic</Package>
-		<Package>python-deprecation</Package>
 		<Package>python-node-semver</Package>
 		<Package>python-patch</Package>
 		<Package>python-pluginbase</Package>


### PR DESCRIPTION
It is needed by `python-pikepdf`.