### PR TITLE
Deprecate old gtk themes

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1167,5 +1167,10 @@
 		<Package>python-genshi-dbginfo</Package>
 		<Package>python-poyo</Package>
 		<Package>budgie-control-center-devel</Package>
+		<Package>adapta-gtk-theme</Package>
+		<Package>evopop-gtk-theme</Package>
+		<Package>gtk-theme-bluebird</Package>
+		<Package>paper-gtk-theme</Package>
+		<Package>vertex-gtk-theme</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1665,5 +1665,12 @@
 
 		<!-- File was removed from upstream -->
 		<Package>budgie-control-center-devel</Package>
+
+		<!-- Old gtk themes abandoned upstream -->
+		<Package>adapta-gtk-theme</Package>
+		<Package>evopop-gtk-theme</Package>
+		<Package>gtk-theme-bluebird</Package>
+		<Package>paper-gtk-theme</Package>
+		<Package>vertex-gtk-theme</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
These themes are abandoned upstream, they have no new releases for a long time.

Theme | Last update
-- | --
paper-gtk-theme | 25-May-16
vertex-gtk-theme | 28-Jan-17
evopop-gtk-theme | 2-Sep-17
adapta-gtk-theme | 2-Oct-18
gtk-theme-bluebird | 24-Nov-18

