### PR TITLE
Deprecate gnome-mpv and appdata-tools

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1171,5 +1171,9 @@
 		<Package>gtk-theme-bluebird</Package>
 		<Package>paper-gtk-theme</Package>
 		<Package>vertex-gtk-theme</Package>
+		<Package>gnome-mpv</Package>
+		<Package>gnome-mpv-dbginfo</Package>
+		<Package>appdata-tools</Package>
+		<Package>appdata-tools-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1671,5 +1671,13 @@
 		<Package>gtk-theme-bluebird</Package>
 		<Package>paper-gtk-theme</Package>
 		<Package>vertex-gtk-theme</Package>
+
+		<!-- Now celluloid -->
+		<Package>gnome-mpv</Package>
+		<Package>gnome-mpv-dbginfo</Package>
+
+		<!-- Obsoleted by appstream-glib -->
+		<Package>appdata-tools</Package>
+		<Package>appdata-tools-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Reference commits:
Update `gnome-mpv` to [celluloid](https://dev.getsol.us/R975:9c575323da5db0139aee6c2c9ec1b1957e76ae85).
Drop `appdata-tools` from [easytag](https://dev.getsol.us/R678:9a541befce1c0b1b8d1faec6420a7bff12b2b89a).