### PR TITLE
Undeprecate adapta-gtk-theme

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1166,7 +1166,6 @@
 		<Package>python-genshi-dbginfo</Package>
 		<Package>python-poyo</Package>
 		<Package>budgie-control-center-devel</Package>
-		<Package>adapta-gtk-theme</Package>
 		<Package>evopop-gtk-theme</Package>
 		<Package>gtk-theme-bluebird</Package>
 		<Package>paper-gtk-theme</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1666,7 +1666,6 @@
 		<Package>budgie-control-center-devel</Package>
 
 		<!-- Old gtk themes abandoned upstream -->
-		<Package>adapta-gtk-theme</Package>
 		<Package>evopop-gtk-theme</Package>
 		<Package>gtk-theme-bluebird</Package>
 		<Package>paper-gtk-theme</Package>


### PR DESCRIPTION
To give us some time to replace it in our branding packages; as requested by @algent-al 