### PR TITLE
Deprecations from GNOME 43 upgrade

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1094,6 +1094,7 @@
 		<Package>goffice0.8</Package>
 		<Package>goffice0.8-dbginfo</Package>
 		<Package>goffice0.8-devel</Package>
+		<Package>goffice0.8-docs</Package>
 		<Package>db4.8</Package>
 		<Package>db4.8-dbginfo</Package>
 		<Package>db4.8-devel</Package>
@@ -1175,5 +1176,16 @@
 		<Package>appdata-tools</Package>
 		<Package>appdata-tools-dbginfo</Package>
 		<Package>python-stem</Package>
+		<Package>nautilus-folder-icons</Package>
+		<Package>gtkhash-nautilus-extension</Package>
+		<Package>nautilus-sendto</Package>
+		<Package>nautilus-sendto-dbginfo</Package>
+		<Package>filemanager-actions-nautilus</Package>
+		<Package>appstream-glib-docs</Package>
+		<Package>gnome-music-dbginfo</Package>
+		<Package>libgweather-docs</Package>
+		<Package>libsecret-docs</Package>
+		<Package>yelp-docs</Package>
+		<Package>vala-panel-appmenu-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1547,6 +1547,7 @@
 		<Package>goffice0.8</Package>
 		<Package>goffice0.8-dbginfo</Package>
 		<Package>goffice0.8-devel</Package>
+		<Package>goffice0.8-docs</Package>
 		<Package>db4.8</Package>
 		<Package>db4.8-dbginfo</Package>
 		<Package>db4.8-devel</Package>
@@ -1681,5 +1682,21 @@
 
 		<!-- Replaced with python-cepa fork from onionshare team -->
 		<Package>python-stem</Package>
+
+		<!-- Doesn't support libnautilus-extensions-4 -->
+		<Package>nautilus-folder-icons</Package>
+		<Package>gtkhash-nautilus-extension</Package>
+		<Package>nautilus-sendto</Package>
+		<Package>nautilus-sendto-dbginfo</Package>
+		<Package>filemanager-actions-nautilus</Package>
+
+		<!-- GNOME 43 deprecations -->
+		<Package>appstream-glib-docs</Package>
+		<Package>gnome-music-dbginfo</Package>
+		<Package>libgweather-docs</Package>
+		<Package>libsecret-docs</Package>
+		<Package>yelp-docs</Package>
+		<Package>vala-panel-appmenu-devel</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Deprecate pkgs that don't support libnautilus-extension-4

Deprecate a few -docs subpackages

And a couple of miscellaneous packages