### PR TITLE
Deprecate librsvg-docs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1185,5 +1185,6 @@
 		<Package>libsecret-docs</Package>
 		<Package>yelp-docs</Package>
 		<Package>vala-panel-appmenu-devel</Package>
+		<Package>librsvg-docs</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1695,6 +1695,7 @@
 		<Package>libsecret-docs</Package>
 		<Package>yelp-docs</Package>
 		<Package>vala-panel-appmenu-devel</Package>
+		<Package>librsvg-docs</Package>
 
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Using gi-docgen instead of gtk-docs these days.

Technically part of GNOME 43 deprecations