### PR TITLE
Deprecate nautilus-terminal

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1185,5 +1185,6 @@
 		<Package>yelp-docs</Package>
 		<Package>vala-panel-appmenu-devel</Package>
 		<Package>librsvg-docs</Package>
+		<Package>nautilus-terminal</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1695,6 +1695,7 @@
 		<Package>yelp-docs</Package>
 		<Package>vala-panel-appmenu-devel</Package>
 		<Package>librsvg-docs</Package>
+		<Package>nautilus-terminal</Package>
 
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
It is being discontinued by the author because of GNOME/Nautilus 43.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>