### PR TITLE
Deprecate font-weather-icons

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1184,5 +1184,6 @@
 		<Package>vala-panel-appmenu-devel</Package>
 		<Package>librsvg-docs</Package>
 		<Package>nautilus-terminal</Package>
+		<Package>font-weather-icons</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1695,5 +1695,8 @@
 		<Package>librsvg-docs</Package>
 		<Package>nautilus-terminal</Package>
 
+		<!-- Splited later to -otf and -ttf -->
+		<Package>font-weather-icons</Package>
+		
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Main package is splitted to font-weather-icons-otf and font-weather-icons-ttf. There is no font-weather-icons package.
Commit [62fd8f9d1565](https://dev.getsol.us/R4094:62fd8f9d15653599129cb0b0bffc6317d3a907ef)