### PR TITLE
InstalledView: Keep details view in "remove only" state

### DIFF
--- a/solus_sc/installed_view.py
+++ b/solus_sc/installed_view.py
@@ -23,6 +23,7 @@ class ScInstalledView(ScPackagesView):
         """ Go back to the main view """
         self.stack.set_visible_child_name("packages")
         self.owner.set_can_back(False)
+        self.details_view.is_install_page = False
 
     def can_back(self):
         """ Whether we can go back """


### PR DESCRIPTION
Otherwise removing a package and going back to the list will show the "Install" action for subsequent package detail views

See e.g. [here](https://www.reddit.com/r/SolusProject/comments/yi1o2v/software_center_bug/) for an issue report

This was the simplest way to do it without restructuring the whole install/remove process that I could find.