### PR TITLE
Deprecate nvidia-container-runtime

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1184,5 +1184,6 @@
 		<Package>vala-panel-appmenu-devel</Package>
 		<Package>librsvg-docs</Package>
 		<Package>nautilus-terminal</Package>
+		<Package>nvidia-container-runtime</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1695,5 +1695,7 @@
 		<Package>librsvg-docs</Package>
 		<Package>nautilus-terminal</Package>
 
+		<!-- Integrated into nvidia-container-toolkit -->
+		<Package>nvidia-container-runtime</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Integrated into nvidia-container-toolkit now https://dev.getsol.us/D13689

To be pushed some time after the next sync

Signed-off-by: Thomas Staudinger <Staudi.Kaos@gmail.com>