### PR TITLE
Deprecate python-backports.entry_points_selectable and python-m2r

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1191,5 +1191,7 @@
 		<Package>nautilus-terminal</Package>
 		<Package>font-weather-icons</Package>
 		<Package>nvidia-container-runtime</Package>
+		<Package>python-m2r</Package>
+		<Package>python-backports.entry_points_selectable</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1710,5 +1710,10 @@
 		<!-- Integrated into nvidia-container-toolkit -->
 		<Package>nvidia-container-runtime</Package>
 
+		<!-- Abandoned upstream. Used to be a dependency for python-automat -->
+		<Package>python-m2r</Package>
+
+		<!-- virtualenv dropped this runtime dependency since version 20.11.0 -->
+		<Package>python-backports.entry_points_selectable</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Signed-off-by: Algent Albrahimi <algent@protonmail.com>