### PR TITLE
Deprecate yuzu-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1191,5 +1191,6 @@
 		<Package>nautilus-terminal</Package>
 		<Package>font-weather-icons</Package>
 		<Package>nvidia-container-runtime</Package>
+		<Package>yuzu-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1709,6 +1709,9 @@
 		
 		<!-- Integrated into nvidia-container-toolkit -->
 		<Package>nvidia-container-runtime</Package>
+		
+		<!-- no more -devel from main package -->
+		<Package>yuzu-devel</Package>
 
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
`yuzu-devel` is no longer built with the `yuzu` package.