### PR TITLE
Deprecate ucl package

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1191,5 +1191,8 @@
 		<Package>nautilus-terminal</Package>
 		<Package>font-weather-icons</Package>
 		<Package>nvidia-container-runtime</Package>
+		<Package>ucl</Package>
+		<Package>ucl-devel</Package>
+		<Package>ucl-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1710,5 +1710,10 @@
 		<!-- Integrated into nvidia-container-toolkit -->
 		<Package>nvidia-container-runtime</Package>
 
+		<!-- Now vendored inside upx itself -->
+		<Package>ucl</Package>
+		<Package>ucl-devel</Package>
+		<Package>ucl-dbginfo</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
This library is now vendored in upx itself (the only user of ucl). 

See [this discussion](https://dev.getsol.us/D13741#235676)