### PR TITLE
Deprecate python-editor and python-idna_ssl

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -345,6 +345,7 @@
 		<Package>profanity-devel</Package>
 		<Package>pithos</Package>
 		<Package>python-alembic</Package>
+		<Package>python-editor</Package>
 		<Package>python-node-semver</Package>
 		<Package>python-patch</Package>
 		<Package>python-pluginbase</Package>
@@ -1196,5 +1197,6 @@
 		<Package>ucl</Package>
 		<Package>ucl-devel</Package>
 		<Package>ucl-dbginfo</Package>
+		<Package>python-idna_ssl</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -495,6 +495,7 @@
 		<Package>profanity-devel</Package>
 		<Package>pithos</Package>
 		<Package>python-alembic</Package>
+		<Package>python-editor</Package>
 		<Package>python-node-semver</Package>
 		<Package>python-patch</Package>
 		<Package>python-pluginbase</Package>
@@ -1720,6 +1721,9 @@
 		<Package>ucl</Package>
 		<Package>ucl-devel</Package>
 		<Package>ucl-dbginfo</Package>
+
+		<!-- Not used by anything -->
+		<Package>python-idna_ssl</Package>
 
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
`python-editor` is a dep for `python-alembic` which is deprecated.
`python-idna_ssl` is not being used by anything in the repo.