### PR TITLE
Deprecate python-cssutils (again)

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1196,5 +1196,6 @@
 		<Package>ucl</Package>
 		<Package>ucl-devel</Package>
 		<Package>ucl-dbginfo</Package>
+		<Package>python-cssutils</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1721,5 +1721,7 @@
 		<Package>ucl-devel</Package>
 		<Package>ucl-dbginfo</Package>
 
+		<!-- Only reverse dependency Gradience switched to an internal solution -->
+		<Package>python-cssutils</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Gradience stopped using it, replacing it with an in-house solution

Corresponding package update: https://dev.getsol.us/R5621:636ca0081dd787b444b9f572b132bfaccce6ee32