### PR TITLE
Deprecate giblib

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1201,5 +1201,6 @@
 		<Package>python-cssutils</Package>
 		<Package>jtreg5</Package>
 		<Package>kwrite</Package>
+		<Package>giblib</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1734,5 +1734,8 @@
 		<!-- Merged back into Kate package -->
 		<Package>kwrite</Package>
 
+		<!-- No longer used by only dependency scrot -->
+		<Package>giblib</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
No longer needed by `scrot` as of this change: https://dev.getsol.us/R2864:18fe9144043a4ef6cff3bbebc894615f1fe0edc4

**Note:** `giblib` is hosted on our own infrastructure, so this can also be removed now:
https://getsol.us/sources/giblib-1.2.4.tar.gz