### PR TITLE
undeprecate puddletag

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -479,7 +479,6 @@
 		<Package>ptlib</Package>
 		<Package>electronic-wechat</Package>
 		<Package>bitmessage</Package>
-		<Package>puddletag</Package>
 		<Package>python-qt4</Package>
 		<Package>python3-qt4</Package>
 		<Package>digikam-kipi-plugins</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -651,7 +651,6 @@
 
 		<!-- sip cleanup and python qt4 deprecation //-->
 		<Package>bitmessage</Package>
-		<Package>puddletag</Package>
 		<Package>python-qt4</Package>
 		<Package>python3-qt4</Package>
 


### PR DESCRIPTION
Resolves https://dev.getsol.us/T10453

`puddletag` was deprecated as part of qt4 deprecation. Now this package switched to python3 and qt5.
Currently I have a working patch.