### PR TITLE
Deprecate python-pysrt

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1201,5 +1201,6 @@
 		<Package>jtreg5</Package>
 		<Package>kwrite</Package>
 		<Package>giblib</Package>
+		<Package>python-pysrt</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1736,5 +1736,8 @@
 		<!-- No longer used by only dependency scrot -->
 		<Package>giblib</Package>
 
+		<!-- Replaced by python-srt -->
+		<Package>python-pysrt</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
`python-pysrt` has been replaced by the more actively maintained `python-srt`, which is also a dependency of `manim`.

To be merged after https://dev.getsol.us/D13754 has landed