### PR TITLE
Deprecate docs subpackages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1201,5 +1201,8 @@
 		<Package>jtreg5</Package>
 		<Package>kwrite</Package>
 		<Package>giblib</Package>
+		<Package>gzdoom-docs</Package>
+		<Package>mpv-docs</Package>
+		<Package>openrct2-docs</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1736,5 +1736,9 @@
 		<!-- No longer used by only dependency scrot -->
 		<Package>giblib</Package>
 
+		<!-- Docs subpackages are not auto-generated anymore -->
+		<Package>gzdoom-docs</Package>
+		<Package>mpv-docs</Package>
+		<Package>openrct2-docs</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Those subpackages are not auto-generated anymore, so these packages can be deprecated.