### PR TITLE
Deprecate old gst-plugins bad good and ugly

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1201,5 +1201,12 @@
 		<Package>jtreg5</Package>
 		<Package>kwrite</Package>
 		<Package>giblib</Package>
+		<Package>gst-plugins-bad</Package>
+		<Package>gst-plugins-bad-dbginfo</Package>
+		<Package>gst-plugins-bad-devel</Package>
+		<Package>gst-plugins-good</Package>
+		<Package>gst-plugins-good-dbginfo</Package>
+		<Package>gst-plugins-ugly</Package>
+		<Package>gst-plugins-ugly-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1736,5 +1736,13 @@
 		<!-- No longer used by only dependency scrot -->
 		<Package>giblib</Package>
 
+		<!-- No longer build, also they aren't rundeps for anything -->
+		<Package>gst-plugins-bad</Package>
+		<Package>gst-plugins-bad-dbginfo</Package>
+		<Package>gst-plugins-bad-devel</Package>
+		<Package>gst-plugins-good</Package>
+		<Package>gst-plugins-good-dbginfo</Package>
+		<Package>gst-plugins-ugly</Package>
+		<Package>gst-plugins-ugly-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Looks like they are not necessary anymore. Other distros like Fedora and Ubuntu have removed it since 6 years ago.

There could be more to deprecate, like:
- `gst-plugins-base`
- `gst-plugins-base-32bit` (This need to be removed from `steam` rundeps)