### PR TITLE
Deprecate Nvidia 390.xx driver series

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -591,6 +591,11 @@
 		<Package>nvidia-340-glx-driver-current</Package>
 		<Package>nvidia-340-glx-driver-modaliases</Package>
 		<Package>nvidia-340-glx-driver</Package>
+		<Package>nvidia-390-glx-driver-32bit</Package>
+		<Package>nvidia-390-glx-driver-common</Package>
+		<Package>nvidia-390-glx-driver-current</Package>
+		<Package>nvidia-390-glx-driver-modaliases</Package>
+		<Package>nvidia-390-glx-driver</Package>
 		<Package>cerebro</Package>
 		<Package>cerebro-dbginfo</Package>
 		<Package>darkradiant</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -822,6 +822,11 @@
 		<Package>nvidia-340-glx-driver-current</Package>
 		<Package>nvidia-340-glx-driver-modaliases</Package>
 		<Package>nvidia-340-glx-driver</Package>
+		<Package>nvidia-390-glx-driver-32bit</Package>
+		<Package>nvidia-390-glx-driver-common</Package>
+		<Package>nvidia-390-glx-driver-current</Package>
+		<Package>nvidia-390-glx-driver-modaliases</Package>
+		<Package>nvidia-390-glx-driver</Package>
 
 		<!-- 2019 and 2020 cleanup //-->
 		<Package>cerebro</Package>


### PR DESCRIPTION
Official support was dropped at the end of 2022

Corresponding doflicky PR: https://github.com/getsolus/doflicky/pull/4
Corresponding xorg-driver-video-nouveau diff: https://dev.getsol.us/D14141