### PR TITLE
Deprecate xdg-desktop-portal-docs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1216,6 +1216,7 @@
 		<Package>gupnp-av-docs</Package>
 		<Package>gupnp-dlna-docs</Package>
 		<Package>openrct2-docs</Package>
+		<Package>xdg-desktop-portal-docs</Package>
 		<Package>cawbird</Package>
 		<Package>cawbird-dbginfo</Package>
 	</Obsoletes>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1756,6 +1756,7 @@
 		<Package>gupnp-av-docs</Package>
 		<Package>gupnp-dlna-docs</Package>
 		<Package>openrct2-docs</Package>
+		<Package>xdg-desktop-portal-docs</Package>
 
 		<!-- Deprecated upstream because of new Twitter policies -->
 		<Package>cawbird</Package>


### PR DESCRIPTION
Removed now that the subpackage is no longer auto-generated