### PR TITLE
repo_data: Deprecate yubioath-desktop

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1224,5 +1224,7 @@
 		<Package>xdg-desktop-portal-docs</Package>
 		<Package>cawbird</Package>
 		<Package>cawbird-dbginfo</Package>
+		<Package>yubioath-desktop</Package>
+		<Package>yubioath-desktop-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1766,5 +1766,9 @@
 		<!-- Deprecated upstream because of new Twitter policies -->
 		<Package>cawbird</Package>
 		<Package>cawbird-dbginfo</Package>
+
+		<!-- Rewritten in flutter by upstream & renamed -->
+		<Package>yubioath-desktop</Package>
+		<Package>yubioath-desktop-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Completely rewritten in flutter and renamed to yubico-authenticator by upstream. Doesn't work with yubikey-manager 5.x