### PR TITLE
Deprecate Budgie desktop branding subpackages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1225,5 +1225,8 @@
 		<Package>cawbird-dbginfo</Package>
 		<Package>yubioath-desktop</Package>
 		<Package>yubioath-desktop-dbginfo</Package>
+		<Package>budgie-desktop-branding-fortitude</Package>
+		<Package>budgie-desktop-branding-fortitude-plus</Package>
+		<Package>budgie-desktop-branding-material</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1769,5 +1769,10 @@
 		<!-- Rewritten in flutter by upstream & renamed -->
 		<Package>yubioath-desktop</Package>
 		<Package>yubioath-desktop-dbginfo</Package>
+
+		<!-- Flattened into one branding package -->
+		<Package>budgie-desktop-branding-fortitude</Package>
+		<Package>budgie-desktop-branding-fortitude-plus</Package>
+		<Package>budgie-desktop-branding-material</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
These packages have been replaced by `budgie-desktop-branding`.