### PR TITLE
Undeprecate mate-desktop-branding main package

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -548,7 +548,6 @@
 		<Package>lbry-app</Package>
 		<Package>lbry-app-dbginfo</Package>
 		<Package>kodi-pvr-iptvsimple</Package>
-		<Package>mate-desktop-branding</Package>
 		<Package>antimicro</Package>
 		<Package>qmc2</Package>
 		<Package>python-faulthandler</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -739,9 +739,6 @@
 		<!-- merged in with kodi //-->
 		<Package>kodi-pvr-iptvsimple</Package>
 
-		<!-- Was replaced with legacy subpackage //-->
-		<Package>mate-desktop-branding</Package>
-
 		<!-- Doesn't build with SDL" update T8184" //-->
 		<Package>antimicro</Package>
 		<Package>qmc2</Package>


### PR DESCRIPTION
Will be used again with the flattening of branding packages