### PR TITLE
Undeprecate gnome-desktop-branding

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -898,7 +898,6 @@
 		<Package>pygoocanvas</Package>
 		<Package>pygoocanvas-dbginfo</Package>
 		<Package>pygoocanvas-devel</Package>
-		<Package>gnome-desktop-branding</Package>
 		<Package>gnome-screensaver</Package>
 		<Package>mozjs38</Package>
 		<Package>mozjs38-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1239,9 +1239,6 @@
 		<Package>pygoocanvas</Package>
 		<Package>pygoocanvas-dbginfo</Package>
 		<Package>pygoocanvas-devel</Package>
-		
-		<!-- Old branding package -->
-		<Package>gnome-desktop-branding</Package>
 
 		<!-- Renamed to budgie-screensaver -->
 		<Package>gnome-screensaver</Package>


### PR DESCRIPTION
We are simplifying and using a singular branding pkg going forward