### PR TITLE
Undeprecate python-multidict

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1020,8 +1020,6 @@
 		<Package>font-awesome-4</Package>
 		<Package>python-yarl</Package>
 		<Package>python-yarl-dbginfo</Package>
-		<Package>python-multidict</Package>
-		<Package>python-multidict-dbginfo</Package>
 		<Package>qt6-location</Package>
 		<Package>qt6-location-dbginfo</Package>
 		<Package>qt6-location-demos</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1441,8 +1441,6 @@
 		<!-- dependency of deprecated package python-aiohttp -->
 		<Package>python-yarl</Package>
 		<Package>python-yarl-dbginfo</Package>
-		<Package>python-multidict</Package>
-		<Package>python-multidict-dbginfo</Package>
 
 		<!-- Upstream dropped this package -->
 		<Package>qt6-location</Package>


### PR DESCRIPTION
Undeprecate Multidict as it is a dependency for the latest version of HTTPie.