### PR TITLE
repo_data: Deprecate gnome-session-shell-experimental

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1233,5 +1233,6 @@
 		<Package>mate-desktop-branding-legacy</Package>
 		<Package>mate-desktop-branding-material</Package>
 		<Package>mate-desktop-branding-shared</Package>
+		<Package>gnome-session-shell-experimental</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1775,5 +1775,9 @@
 		<Package>mate-desktop-branding-legacy</Package>
 		<Package>mate-desktop-branding-material</Package>
 		<Package>mate-desktop-branding-shared</Package>
+
+		<!-- GNOME Wayland sessions no longer experimental -->
+		<Package>gnome-session-shell-experimental</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
The GNOME Wayland sessions are no longer experimental