### PR TITLE
repo_data: Initial haskell deprecations from static built bustle

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1253,5 +1253,26 @@
 		<Package>gnome-session-shell-experimental</Package>
 		<Package>dleyna-connector-dbus-devel</Package>
 		<Package>pipewire-alsa</Package>
+		<Package>haskell-dbus</Package>
+		<Package>haskell-dbus-dbginfo</Package>
+		<Package>haskell-dbus-devel</Package>
+		<Package>haskell-gtk3</Package>
+		<Package>haskell-gtk3-dbginfo</Package>
+		<Package>haskell-gtk3-devel</Package>
+		<Package>haskell-pango</Package>
+		<Package>haskell-pango-dbginfo</Package>
+		<Package>haskell-pango-devel</Package>
+		<Package>haskell-gio</Package>
+		<Package>haskell-gio-dbginfo</Package>
+		<Package>haskell-gio-devel</Package>
+		<Package>haskell-glib</Package>
+		<Package>haskell-glib-dbginfo</Package>
+		<Package>haskell-glib-devel</Package>
+		<Package>haskell-cairo</Package>
+		<Package>haskell-cairo-dbginfo</Package>
+		<Package>haskell-cairo-devel</Package>
+		<Package>gtk2hs-buildtools</Package>
+		<Package>gtk2hs-buildtools-dbginfo</Package>
+		<Package>gtk2hs-buildtools-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1812,5 +1812,28 @@
 
 		<!-- Merged into the main package -->
 		<Package>pipewire-alsa</Package>
+
+		<!-- Static haskell stack, initial deprecations from bustle -->
+		<Package>haskell-dbus</Package>
+		<Package>haskell-dbus-dbginfo</Package>
+		<Package>haskell-dbus-devel</Package>
+		<Package>haskell-gtk3</Package>
+		<Package>haskell-gtk3-dbginfo</Package>
+		<Package>haskell-gtk3-devel</Package>
+		<Package>haskell-pango</Package>
+		<Package>haskell-pango-dbginfo</Package>
+		<Package>haskell-pango-devel</Package>
+		<Package>haskell-gio</Package>
+		<Package>haskell-gio-dbginfo</Package>
+		<Package>haskell-gio-devel</Package>
+		<Package>haskell-glib</Package>
+		<Package>haskell-glib-dbginfo</Package>
+		<Package>haskell-glib-devel</Package>
+		<Package>haskell-cairo</Package>
+		<Package>haskell-cairo-dbginfo</Package>
+		<Package>haskell-cairo-devel</Package>
+		<Package>gtk2hs-buildtools</Package>
+		<Package>gtk2hs-buildtools-dbginfo</Package>
+		<Package>gtk2hs-buildtools-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
We're building all our haskell programs as static, starting now; to ease maintainership burden.

Here are the initial haskell deprecations from building bustle as static.

https://dev.getsol.us/D14119