### PR TITLE
Add templates for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/deprecation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/deprecation.md
@@ -1,0 +1,14 @@
+## Reason
+_Reason for deprecation or undeprecation_
+
+< Reason here >
+
+## Does this request depend on package changes to land first?
+_This request depends on a package change to land before this can be merged._
+
+[ ] Yes
+
+## Package Diff
+_The URL to the package change this depends on, if any_
+
+< Diff URL >

--- a/.github/PULL_REQUEST_TEMPLATE/deprecation.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/deprecation.yml
@@ -1,0 +1,26 @@
+name: Deprecation/Undeprecation
+description: Request to deprecate or undeprecate a package
+title: "[Un/Deprecation] "
+body:
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason
+      description: Reason for deprecation or undeprecation
+    validation:
+      required: true
+
+  - type: checkboxes
+    id: depends-on
+    attributes:
+      label: Does this request depend on package changes to land first?
+      description: This request depends on a package change to land before this can be merged.
+      options:
+        - label: Yes
+
+  - type: input
+    id: diff-url
+    attributes:
+      label: Package Diff
+      description: The URL to the package change this depends on, if any
+      placeholder: https://dev.getsol.us/D00000

--- a/.github/PULL_REQUEST_TEMPLATE/other.md
+++ b/.github/PULL_REQUEST_TEMPLATE/other.md
@@ -1,0 +1,10 @@
+## Description
+_Details about what this Pull Request does_
+
+< Describe the pull request >
+
+## Submitter Checklist
+_Check all that apply_
+
+[ ] Squashed commits with `git rebase -i` (if needed)  
+[ ] Built solus-sc and verified that the patch worked (if needed)

--- a/.github/PULL_REQUEST_TEMPLATE/other.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/other.yml
@@ -1,0 +1,21 @@
+name: Other
+description: Any other code change
+title: ""
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Details about what this Pull Request does
+      placeholder: This pull request does...
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Submitter Checklist
+      description: Check all that apply
+      options:
+        - label: "Squashed commits with `git rebase -i` (if needed)"
+        - label: Built solus-sc and verified that the patch worked (if needed)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+Please go the the `Preview` tab and select the appropriate sub-template:
+
+* [Deprecation or Undeprecation](?expand=1&template=deprecation.md)
+* [Other](?expand=1&template=other.md)


### PR DESCRIPTION
This adds templates for creating a Pull Request, depending on if it is a package deprecation or undeprecation, or any other code change.

This includes template files in both .yml and .md because I didn't realize that GitHub only supports the new yaml formatting for issue template, and not pull requests. I didn't remove them in the hopes that GitHub will one day support them, and when that day comes, we won't have to do the work again.

GitHub also doesn't have a built-in way to select what template you want to use when creating the pull request, like they do for issues. Apparently, it's on the roadmap. Thus, we have to do this hacky thing with a default template that has links to use one of the other templates.