### PR TITLE
deprecate libatk and at-spi2

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -188,6 +188,17 @@
 		<Package>autotrace</Package>
 		<Package>autotrace-devel</Package>
 		<Package>gnome-tweak-tool</Package>
+		<Package>libatk</Package>
+		<Package>libatk-devel</Package>
+		<Package>libatk-dbginfo</Package>
+		<Package>libatk-32bit</Package>
+		<Package>libatk-32bit-devel</Package>
+		<Package>libatk-32bit-dbginfo</Package>
+		<Package>at-spi2-atk</Package>
+		<Package>at-spi2-atk-devel</Package>
+		<Package>at-spi2-atk-32bit</Package>
+		<Package>at-spi2-atk-32bit-dbginfo</Package>
+		<Package>at-spi2-atk-32bit-devel</Package>
 		<Package>nautilus-actions</Package>
 		<Package>nautilus-actions-dbginfo</Package>
 		<Package>nautilus-actions-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -291,6 +291,19 @@
 
 		<!-- Replaced by gnome-tweaks //-->
 		<Package>gnome-tweak-tool</Package>
+		
+		<!-- libatk and at-spi2 merged into at-spi2 //-->
+		<Package>libatk</Package>
+		<Package>libatk-devel</Package>
+		<Package>libatk-dbginfo</Package>
+		<Package>libatk-32bit</Package>
+		<Package>libatk-32bit-devel</Package>
+		<Package>libatk-32bit-dbginfo</Package>
+		<Package>at-spi2-atk</Package>
+		<Package>at-spi2-atk-devel</Package>
+		<Package>at-spi2-atk-32bit</Package>
+		<Package>at-spi2-atk-32bit-dbginfo</Package>
+		<Package>at-spi2-atk-32bit-devel</Package>
 
 		<!-- Replaced by filemanager-actions //-->
 		<Package>nautilus-actions</Package>


### PR DESCRIPTION
Now that things have been rebuilt against at-spi2 now, let's deprecate libatk and at-spi2 itself.