### PR TITLE
Undeprecate dleyna-renderer, deprecate dleyna-connector-dbus-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -483,8 +483,6 @@
 		<Package>python-qt4</Package>
 		<Package>python3-qt4</Package>
 		<Package>digikam-kipi-plugins</Package>
-		<Package>dleyna-renderer</Package>
-		<Package>dleyna-renderer-devel</Package>
 		<Package>frogr</Package>
 		<Package>empathy</Package>
 		<Package>galculator</Package>
@@ -1238,5 +1236,6 @@
 		<Package>boostnote</Package>
 		<Package>boostnote-dbginfo</Package>
 		<Package>gnome-session-shell-experimental</Package>
+		<Package>dleyna-connector-dbus-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -659,8 +659,6 @@
 		<Package>digikam-kipi-plugins</Package>
 
 		<!-- Part of GNOME Stack Cleanup //-->
-		<Package>dleyna-renderer</Package>
-		<Package>dleyna-renderer-devel</Package>
 		<Package>frogr</Package>
 		<Package>empathy</Package>
 		<Package>galculator</Package>
@@ -1786,6 +1784,9 @@
 
 		<!-- GNOME Wayland sessions no longer experimental -->
 		<Package>gnome-session-shell-experimental</Package>
+
+		<!-- In merging the dleyna repos, they removed this part -->
+		<Package>dleyna-connector-dbus-devel</Package>
 
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Result of changes in the dleyna packaging, and upstream changes.