### PR TITLE
repo_data: Deprecate pipewire-alsa

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1237,5 +1237,6 @@
 		<Package>boostnote-dbginfo</Package>
 		<Package>gnome-session-shell-experimental</Package>
 		<Package>dleyna-connector-dbus-devel</Package>
+		<Package>pipewire-alsa</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1788,5 +1788,7 @@
 		<!-- In merging the dleyna repos, they removed this part -->
 		<Package>dleyna-connector-dbus-devel</Package>
 
+		<!-- Merged into the main package -->
+		<Package>pipewire-alsa</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
This depends on [D14217](https://dev.getsol.us/D14217).