### PR TITLE
repo_data: Deprecate python2-pytest

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1274,5 +1274,6 @@
 		<Package>gtk2hs-buildtools-devel</Package>
 		<Package>python-enum34</Package>
 		<Package>python2-pyflakes</Package>
+		<Package>python2-pytest</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1841,5 +1841,6 @@
 		<!-- No longer needed by anything -->
 		<Package>python-enum34</Package>
 		<Package>python2-pyflakes</Package>
+		<Package>python2-pytest</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
No longer tests anything critical. Continued python2 deprecation