### PR TITLE
repo_date: Deprecate discord-dbginfo

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1275,5 +1275,6 @@
 		<Package>python-enum34</Package>
 		<Package>python2-pyflakes</Package>
 		<Package>python2-pytest</Package>
+		<Package>discord-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1842,5 +1842,8 @@
 		<Package>python-enum34</Package>
 		<Package>python2-pyflakes</Package>
 		<Package>python2-pytest</Package>
+
+		<!-- Debug disabled for this package -->
+		<Package>discord-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Debug was disabled awhile back in order to fix krisp noise suppression.

https://dev.getsol.us/R628:943efe3d176e4beb1d222c2220473c0457e110d3