### PR TITLE
Deprecate not used perl packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1286,5 +1286,31 @@
 		<Package>python2-setuptools-scm</Package>
 		<Package>python2-packaging</Package>
 		<Package>discord-dbginfo</Package>
+		<Package>perl-config-simple</Package>
+		<Package>perl-cpan-changes</Package>
+		<Package>perl-date-simple</Package>
+		<Package>perl-date-simple-dbginfo</Package>
+		<Package>perl-dbd-sqlite</Package>
+		<Package>perl-dbd-sqlite-dbginfo</Package>
+		<Package>perl-extutils-embed</Package>
+		<Package>perl-extutils-xspp</Package>
+		<Package>perl-file-path</Package>
+		<Package>perl-file-temp</Package>
+		<Package>perl-getopt-long</Package>
+		<Package>perl-gtk2-ex-podviewer</Package>
+		<Package>perl-gtk2-ex-simple-list</Package>
+		<Package>perl-io-stringy</Package>
+		<Package>perl-mime-base64</Package>
+		<Package>perl-mime-base64-dbginfo</Package>
+		<Package>perl-net-smtp-ssl</Package>
+		<Package>perl-path-iter</Package>
+		<Package>perl-pathtools</Package>
+		<Package>perl-pathtools-dbginfo</Package>
+		<Package>perl-pod-usage</Package>
+		<Package>perl-sgmlspm</Package>
+		<Package>perl-test-distmanifest</Package>
+		<Package>perl-text-charwidth</Package>
+		<Package>perl-text-charwidth-dbginfo</Package>
+		<Package>perl-test-perltidy</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1855,5 +1855,33 @@
 
 		<!-- Debug disabled for this package -->
 		<Package>discord-dbginfo</Package>
+
+		<!-- Perl packages that are not being used by anything -->
+		<Package>perl-config-simple</Package>
+		<Package>perl-cpan-changes</Package>
+		<Package>perl-date-simple</Package>
+		<Package>perl-date-simple-dbginfo</Package>
+		<Package>perl-dbd-sqlite</Package>
+		<Package>perl-dbd-sqlite-dbginfo</Package>
+		<Package>perl-extutils-embed</Package>
+		<Package>perl-extutils-xspp</Package>
+		<Package>perl-file-path</Package>
+		<Package>perl-file-temp</Package>
+		<Package>perl-getopt-long</Package>
+		<Package>perl-gtk2-ex-podviewer</Package>
+		<Package>perl-gtk2-ex-simple-list</Package>
+		<Package>perl-io-stringy</Package>
+		<Package>perl-mime-base64</Package>
+		<Package>perl-mime-base64-dbginfo</Package>
+		<Package>perl-net-smtp-ssl</Package>
+		<Package>perl-path-iter</Package>
+		<Package>perl-pathtools</Package>
+		<Package>perl-pathtools-dbginfo</Package>
+		<Package>perl-pod-usage</Package>
+		<Package>perl-sgmlspm</Package>
+		<Package>perl-test-distmanifest</Package>
+		<Package>perl-text-charwidth</Package>
+		<Package>perl-text-charwidth-dbginfo</Package>
+		<Package>perl-test-perltidy</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Many of these are part of [T2165](https://dev.getsol.us/T2165) for inclusion of `ClusterSSH` which was not resolved.
Some are deps of deprecated package `x2goserver` and for some other there is no info why they are added on first place.