### PR TITLE
repo_data: Deprecate Budgie Trash Applet

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1312,5 +1312,6 @@
 		<Package>perl-text-charwidth</Package>
 		<Package>perl-text-charwidth-dbginfo</Package>
 		<Package>perl-test-perltidy</Package>
+		<Package>budgie-trash-applet</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1883,5 +1883,8 @@
 		<Package>perl-text-charwidth</Package>
 		<Package>perl-text-charwidth-dbginfo</Package>
 		<Package>perl-test-perltidy</Package>
+
+		<!-- Included in Budgie Desktop now -->
+		<Package>budgie-trash-applet</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

This applet is now included in Budgie Desktop.

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

[ ] Yes

## Package Diff
_The URL to the package change this depends on, if any_

n/a
