### PR TITLE
repo_data: Deprecate ldc-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1317,5 +1317,6 @@
 		<Package>perl-text-charwidth-dbginfo</Package>
 		<Package>perl-test-perltidy</Package>
 		<Package>budgie-trash-applet</Package>
+		<Package>ldc-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1892,5 +1892,8 @@
 
 		<!-- Included in Budgie Desktop now -->
 		<Package>budgie-trash-applet</Package>
+
+		<!-- ldc-devel moved to ldc, ldc moved to ldc-libs -->
+		<Package>ldc-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
ldc-devel has been moved to ldc, ldc has been moved to ldc-libs

## Does this request depend on package changes to land first?
[ ] Yes

## Package Diff

[< Diff URL >](https://github.com/solus-packages/ldc/tree/ldc-1.34.0-59)
