### PR TITLE
repo_data: Deprecate gnome-shell-extension-topicons-plus

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2210,5 +2210,6 @@
 		<Package>libnm-legacy-dbginfo</Package>
 		<Package>libnm-legacy-32bit</Package>
 		<Package>libnm-legacy-32bit-dbginfo</Package>
+		<Package>gnome-shell-extension-topicons-plus</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2813,5 +2813,8 @@
 		<Package>libnm-legacy-dbginfo</Package>
 		<Package>libnm-legacy-32bit</Package>
 		<Package>libnm-legacy-32bit-dbginfo</Package>
+
+		<!-- Doesn't support appindicator or wayland, unlike it's replacement gnome-shell-extension-appindicator -->
+		<Package>gnome-shell-extension-topicons-plus</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
Replaced by gnome-shell-extension-appindicator which provides better overall support

## Does this request depend on package changes to land first?
[ ] Yes

## Package Diff
https://github.com/solus-packages/gnome-shell-extension-appindicator/commit/fcde27c114a11838d7e0ac5bed77c9582f9c22b0
