### PR TITLE
Deprecate python-cchardet and python-arpeggio

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1322,6 +1322,9 @@
 		<Package>budgie-trash-applet</Package>
 		<Package>ldc-devel</Package>
 		<Package>oxygen-sound-theme</Package>
+		<Package>python-cchardet</Package>
+		<Package>python-cchardet-dbginfo</Package>
+		<Package>python-arpeggio</Package>
 		<Package>cpphs</Package>
 		<Package>cpphs-devel</Package>
 		<Package>data-default-instances-containers</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1902,6 +1902,13 @@
 		<!-- Has been removed since release 75 of oxygen -->
 		<Package>oxygen-sound-theme</Package>
 
+		<!-- No longer maintained and replaced with python-faust-cchardet -->	
+		<Package>python-cchardet</Package>
+		<Package>python-cchardet-dbginfo</Package>
+		
+		<!-- No longer needed, dep of deprecated package python-parver -->
+		<Package>python-arpeggio</Package>
+
 		<!-- Haskell stack upgrade -->
 		<Package>cpphs</Package>
 		<Package>cpphs-devel</Package>


### PR DESCRIPTION
## Reason

`python-cchardet` is no longer maintained and replaced with a fork `python-faust-cchardet`
`python-arpeggio` is no longer needed. It was a dep  `python-parver` which is already deprecated.

## Does this request depend on package changes to land first?
The changes are already made on `python-faust-cchardet` by adding `replaces` section.
