### PR TITLE
Deprecate exa

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2182,5 +2182,6 @@
 		<Package>haskell-yaml-dbginfo</Package>
 		<Package>haskell-zip-archive-dbginfo</Package>
 		<Package>haskell-zlib-bindings-dbginfo</Package>
+		<Package>exa</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2763,5 +2763,8 @@
 		<Package>haskell-yaml-dbginfo</Package>
 		<Package>haskell-zip-archive-dbginfo</Package>
 		<Package>haskell-zlib-bindings-dbginfo</Package>
+
+		<!-- Replaced by eza -->
+		<Package>exa</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

Exa has been discontinued upstream and replaced by a fork called eza.

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

[ ] Yes

## Package Diff
_The URL to the package change this depends on, if any_

n/a
