### PR TITLE
Deprecate libmemcached

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -276,6 +276,9 @@
 		<Package>trousers-devel</Package>
 		<Package>valum</Package>
 		<Package>valum-devel</Package>
+		<Package>libmemcached</Package>
+		<Package>libmemcached-dbginfo</Package>
+		<Package>libmemcached-devel</Package>
 		<Package>bigreqsproto</Package>
 		<Package>compositeproto</Package>
 		<Package>damageproto</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -423,6 +423,11 @@
 		<Package>valum</Package>
 		<Package>valum-devel</Package>
 
+		<!-- Dependency of valum -->
+		<Package>libmemcached</Package>
+		<Package>libmemcached-dbginfo</Package>
+		<Package>libmemcached-devel</Package>
+
 		<!-- Merged in xorgproto //-->
 		<Package>bigreqsproto</Package>
 		<Package>compositeproto</Package>


### PR DESCRIPTION
## Reason

This is a dependency of  `valum` which was deprecated a long time ago.

## Does this request depend on package changes to land first?

- [x] No