### PR TITLE
libeconf-32bit: Back from the dead

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2186,8 +2186,5 @@
 		<Package>haskell-zip-archive-dbginfo</Package>
 		<Package>haskell-zlib-bindings-dbginfo</Package>
 		<Package>exa</Package>
-		<Package>libeconf-32bit</Package>
-		<Package>libeconf-32bit-dbginfo</Package>
-		<Package>libeconf-32bit-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2773,10 +2773,5 @@
 
 		<!-- Replaced by eza -->
 		<Package>exa</Package>
-				
-		<!-- Was built but not actually needed -->
-		<Package>libeconf-32bit</Package>
-		<Package>libeconf-32bit-dbginfo</Package>
-		<Package>libeconf-32bit-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
I actually _do_ need these packages for pam-32bit.
