### PR TITLE
Deprecate jitsi

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2193,5 +2193,7 @@
 		<Package>julia-devel</Package>
 		<Package>julia-docs</Package>
 		<Package>julia-dbginfo</Package>
+		<Package>jitsi</Package>
+		<Package>jitsi-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2784,5 +2784,9 @@
 		<Package>julia-devel</Package>
 		<Package>julia-docs</Package>
 		<Package>julia-dbginfo</Package>
+
+		<!-- Not needed by anything -->
+		<Package>jitsi</Package>
+		<Package>jitsi-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
It was pointed out that this was not deprecated properly twice in Matrix chat. Once back in July (still on phab?) and again recently when GZ noticed it was in the binary repo but not the monorepo.

## Does this request depend on package changes to land first?
No
