### PR TITLE
Deprecate dhclient, libnm-legacy

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2203,5 +2203,11 @@
 		<Package>qt6.5d-demos</Package>
 		<Package>qt6.5d-devel</Package>
 		<Package>qt6.5d-dbginfo</Package>
+		<Package>dhclient</Package>
+		<Package>dhclient-dbginfo</Package>
+		<Package>libnm-legacy</Package>
+		<Package>libnm-legacy-dbginfo</Package>
+		<Package>libnm-legacy-32bit</Package>
+		<Package>libnm-legacy-32bit-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2802,5 +2802,13 @@
 		<Package>qt6.5d-demos</Package>
 		<Package>qt6.5d-devel</Package>
 		<Package>qt6.5d-dbginfo</Package>
+
+		<!-- No longer needed -->
+		<Package>dhclient</Package>
+		<Package>dhclient-dbginfo</Package>
+		<Package>libnm-legacy</Package>
+		<Package>libnm-legacy-dbginfo</Package>
+		<Package>libnm-legacy-32bit</Package>
+		<Package>libnm-legacy-32bit-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
No longer needed

## Does this request depend on package changes to land first?

[x] Yes

## Package Diff
https://github.com/getsolus/packages/pull/426
