### PR TITLE
changelog: remove html comments (from PR template)

### DIFF
--- a/solus_sc/changelog.py
+++ b/solus_sc/changelog.py
@@ -37,6 +37,7 @@ GENERAL_URI = re.compile(r"""(?i)\b((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d\
 MARKUP_URI_HIT = re.compile(r"\[({})\]\(({})\)".format("[^\]]+", "[^)]+"))
 MARKUP_CODE_HIT = re.compile(r"`([^`]+)`")
 MARKUP_BOLD_HIT = re.compile(r"\*{2}([^\*{2}]+)\*{2}")
+MARKUP_COMMENT_HIT = re.compile(r"&lt;!--.*--&gt;")
 
 
 class ScChangelogEntry(Gtk.EventBox):
@@ -53,6 +54,10 @@ class ScChangelogEntry(Gtk.EventBox):
 
         # Iterate all the lines
         for r in text.split("\n"):
+            # Skip this line early if it's an HTML comment
+            if MARKUP_COMMENT_HIT.match(r):
+                continue
+
             # Save number of leading spaces for bullet point indentation
             lspaces = len(r) - len(r.lstrip())
             r = r.strip()


### PR DESCRIPTION
## Description

Since our new PR template for the packages repo contains html comments these might at times land in an actual commit.
This PR removes lines with comments before displaying the changelog.

Before:
![](https://i.imgur.com/7LO1kDn.png)
After:
![](https://i.imgur.com/mf2ASep.png)
## Submitter Checklist

[x] Squashed commits with `git rebase -i` (if needed)  
[x] Built solus-sc and verified that the patch worked (if needed)
