### PR TITLE
Remove leftover reference to google-talk-plugin

### DIFF
--- a/eopkg_assist/backend.py
+++ b/eopkg_assist/backend.py
@@ -57,8 +57,6 @@ APPS = {
         "office/moneydance/pspec.xml",
     "ocenaudio":
         "multimedia/music/ocenaudio/pspec.xml",
-    "google-talkplugin":
-        "network/im/google-talkplugin/pspec.xml",
     "plexmediaserver":
         "multimedia/video/plexmediaserver/pspec.xml",
     "pycharm":


### PR DESCRIPTION
## Description
_Details about what this Pull Request does_

This removes one reference to the long-removed google-talk-plugin from the Third Party repo.

## Submitter Checklist
_Check all that apply_

- [x] Squashed commits with `git rebase -i` (if needed)  
- [x] Built solus-sc and verified that the patch worked (if needed)
