### PR TITLE
deprecate mage

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2197,5 +2197,7 @@
 		<Package>julia-dbginfo</Package>
 		<Package>jitsi</Package>
 		<Package>jitsi-dbginfo</Package>
+		<Package>mage</Package>
+		<Package>mage-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2792,5 +2792,10 @@
 		<!-- Not needed by anything -->
 		<Package>jitsi</Package>
 		<Package>jitsi-dbginfo</Package>
+
+		<!-- Not needed for hugo -->
+		<Package>mage</Package>
+		<Package>mage-dbginfo</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

Mage was originally introduced to build hugo. Hugo doesn't need it anymore.

## Does this request depend on package changes to land first?

*No*

## Package PR

https://github.com/getsolus/packages/pull/530
