### PR TITLE
repo_data: remove some forgotten Haskell packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1479,6 +1479,8 @@
 		<Package>haskell-doctemplates-devel</Package>
 		<Package>haskell-easy-file</Package>
 		<Package>haskell-easy-file-devel</Package>
+		<Package>haskell-either</Package>
+		<Package>haskell-either-devel</Package>
 		<Package>haskell-enclosed-exceptions</Package>
 		<Package>haskell-enclosed-exceptions-devel</Package>
 		<Package>haskell-errors</Package>
@@ -1708,6 +1710,8 @@
 		<Package>haskell-profunctors-devel</Package>
 		<Package>haskell-project-template</Package>
 		<Package>haskell-project-template-devel</Package>
+		<Package>haskell-psqueues</Package>
+		<Package>haskell-psqueues-devel</Package>
 		<Package>haskell-quickcheck-io</Package>
 		<Package>haskell-quickcheck-io-devel</Package>
 		<Package>haskell-reflection</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2066,6 +2066,8 @@
 		<Package>haskell-doctemplates-devel</Package>
 		<Package>haskell-easy-file</Package>
 		<Package>haskell-easy-file-devel</Package>
+		<Package>haskell-either</Package>
+		<Package>haskell-either-devel</Package>
 		<Package>haskell-enclosed-exceptions</Package>
 		<Package>haskell-enclosed-exceptions-devel</Package>
 		<Package>haskell-errors</Package>
@@ -2295,6 +2297,8 @@
 		<Package>haskell-profunctors-devel</Package>
 		<Package>haskell-project-template</Package>
 		<Package>haskell-project-template-devel</Package>
+		<Package>haskell-psqueues</Package>
+		<Package>haskell-psqueues-devel</Package>
 		<Package>haskell-quickcheck-io</Package>
 		<Package>haskell-quickcheck-io-devel</Package>
 		<Package>haskell-reflection</Package>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

Remnants of the Haskell stack update. These lucky packages escaped the mass deprecation because they have a mis-spelled category.

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [ ] Yes

## Package PR
_The URL to the package change this depends on, if any_

n/a
