### PR TITLE
Add desktop-entry hint for solus-update-checker notifications

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     scripts         = ['solus-sc', 'solus-update-checker'],
     classifiers     = [ "License :: OSI Approved :: GPL-2.0 License"],
     package_data    = {'solus_sc': ['data/update_dialog.ui', 'data/styling.css', 'data/arc.css', 'data/settings.ui']},
-    data_files      = [("/usr/share/applications", ["data/solus-sc.desktop"]),
+    data_files      = [("/usr/share/applications", ["data/solus-sc.desktop", "data/solus-update.desktop"]),
                        ("/usr/share/dbus-1/system-services", ["data/dbus-1/system-services/com.solus_project.eopkgassist.service"]),
                        ("/usr/share/dbus-1/system.d", ["data/system.d/com.solus_project.eopkgassist.conf"]),
                        ("/usr/share/glib-2.0/schemas", ["data/com.solus-project.software-center.gschema.xml"]),

--- a/solus_update/application.py
+++ b/solus_update/application.py
@@ -309,6 +309,7 @@ class ScUpdateApp(Gio.Application):
 
         self.notification = Notify.Notification.new(title, body, icon_name)
         self.notification.set_timeout(UPDATE_NOTIF_TIMEOUT)
+        self.notification.set_hint_string("desktop-entry", "solus-update")
         self.notification.add_action("open-sc", _("Open Software Center"),
                                      self.action_show_updates, None)
         self.notification.show()


### PR DESCRIPTION
## Description
_Details about what this Pull Request does_

This ensures that notifications from solus-update-checker can get the right Desktop Application Info file, since the file does not match the application ID.

That they should match is another issue, but for now, this will do.

Ref https://github.com/BuddiesOfBudgie/budgie-desktop/pull/479

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

## Submitter Checklist
_Check all that apply_

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built solus-sc and verified that the patch worked (if needed)