### PR TITLE
repo_data: Deprecate python-funcsigs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2199,6 +2199,7 @@
 		<Package>jitsi-dbginfo</Package>
 		<Package>mage</Package>
 		<Package>mage-dbginfo</Package>
+		<Package>python-funcsigs</Package>
 		<Package>qt6.5d</Package>
 		<Package>qt6.5d-demos</Package>
 		<Package>qt6.5d-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2797,6 +2797,9 @@
 		<Package>mage</Package>
 		<Package>mage-dbginfo</Package>
 
+		<!-- Not needed for py3 python-mock -->
+		<Package>python-funcsigs</Package>
+
 		<!-- Just an unfortunate typo, correct name is qt6-3d -->
 		<Package>qt6.5d</Package>
 		<Package>qt6.5d-demos</Package>


### PR DESCRIPTION
## Reason
This was a dependency for python2 python-mock

## Does this request depend on package changes to land first?

- No

## Package PR
https://github.com/getsolus/packages/pull/585