### PR TITLE
distribution.xml.in: Make gnome-sound-recorder available again and deprecate amtk

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -752,7 +752,6 @@
 		<Package>ruby-redcarpet-dbginfo</Package>
 		<Package>ruby-yard</Package>
 		<Package>ruby-mustache</Package>
-		<Package>gnome-sound-recorder</Package>
 		<Package>noise</Package>
 		<Package>noise-dbginfo</Package>
 		<Package>noise-devel</Package>
@@ -2219,5 +2218,8 @@
 		<Package>libusd</Package>
 		<Package>libusd-dbginfo</Package>
 		<Package>libusd-devel</Package>
+		<Package>amtk</Package>
+		<Package>amtk-devel</Package>
+		<Package>amtk-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -857,7 +857,7 @@
 
 		<!-- No more doc subpackage with update to 1.1.28 //-->
 		<Package>libpaper-docs</Package>
-		
+
 		<!-- RIP in 3.36 Stack Upgrade //-->
 		<Package>gcr-docs</Package>
 		<Package>gedit-docs</Package>
@@ -1045,7 +1045,6 @@
 		<Package>ruby-mustache</Package>
 
 		<!-- Upgrade requires libhandy and thus removed from repo //-->
-		<Package>gnome-sound-recorder</Package>
 		<Package>noise</Package>
 		<Package>noise-dbginfo</Package>
 		<Package>noise-devel</Package>
@@ -1482,7 +1481,7 @@
 		<Package>monodevelop</Package>
 		<Package>monodevelop-dbginfo</Package>
 		<Package>monodevelop-devel</Package>
-    
+	
 		<!-- Temporary package which helped handle libgit2 rebuilds -->
 		<Package>libgit2solbuild</Package>
 		<Package>libgit2solbuild-dbginfo</Package>
@@ -1630,7 +1629,7 @@
 
 		<!-- Not being used by anything. opencv moved to eigen3 -->
 		<Package>eigen2</Package>
-    
+	
 		<!-- not used anymore -->
 		<Package>libkvkontakte</Package>
 		<Package>libkvkontakte-devel</Package>
@@ -1712,7 +1711,6 @@
 		<Package>vala-panel-appmenu-devel</Package>
 		<Package>librsvg-docs</Package>
 		<Package>nautilus-terminal</Package>
-
 		<!-- Splited later to -otf and -ttf -->
 		<Package>font-weather-icons</Package>
 
@@ -2828,5 +2826,10 @@
 		<Package>libusd</Package>
 		<Package>libusd-dbginfo</Package>
 		<Package>libusd-devel</Package>
+
+		<!-- amtk replaced by libgedit-amtk //-->
+		<Package>amtk</Package>
+		<Package>amtk-devel</Package>
+		<Package>amtk-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
We don't discriminate against libhandy or libadwaita anymore, also in this PR is deprecating amtk since it has been renamed to libgedit-amtk

## Does this request depend on package changes to land first?.

- [x] No
