### PR TITLE
repo_data: Deprecate old electron apps that don't support clone3

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2210,5 +2210,9 @@
 		<Package>libnm-legacy-dbginfo</Package>
 		<Package>libnm-legacy-32bit</Package>
 		<Package>libnm-legacy-32bit-dbginfo</Package>
+		<Package>pencil</Package>
+		<Package>pencil-dbginfo</Package>
+		<Package>simplenote</Package>
+		<Package>simplenote-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2813,5 +2813,12 @@
 		<Package>libnm-legacy-dbginfo</Package>
 		<Package>libnm-legacy-32bit</Package>
 		<Package>libnm-legacy-32bit-dbginfo</Package>
+
+		<!-- Old electron apps that have no clone3 support and -->
+		<Package>pencil</Package>
+		<Package>pencil-dbginfo</Package>
+		<Package>simplenote</Package>
+		<Package>simplenote-dbginfo</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
Electron apps that were never updated to support glibc clone3 and thus don't launch.

## Does this request depend on package changes to land first?

- [ ] Yes

## Package PR
https://github.com/getsolus/packages/pull/673
