### PR TITLE
repo_data: Deprecate chrome-gnome-shell

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2227,5 +2227,6 @@
 		<Package>zlib-minizip-devel</Package>
 		<Package>libnettle-devel</Package>
 		<Package>libnettle-32bit-devel</Package>
+		<Package>chrome-gnome-shell</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2843,5 +2843,11 @@
 		<!-- Merged back into nettle-devel -->
 		<Package>libnettle-devel</Package>
 		<Package>libnettle-32bit-devel</Package>
+
+		<!-- Replaced by having `gnome-browser-connector` installed -->
+		<!-- and extensions.gnome.org prompting to install an extension -->
+		<!-- for the relevant browser -->
+		<!-- Replaced by gnome-browser-extension upstream -->
+		<Package>chrome-gnome-shell</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
Replaced by having `gnome-browser-connector` installed and extensions.gnome.org prompting to install an extension for the relevant browser. Replaced by gnome-browser-extension upstream

## Does this request depend on package changes to land first?

- [ ] Yes

## Package PR

N/A
