### PR TITLE
Deprecate gtest-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2228,5 +2228,6 @@
 		<Package>libnettle-devel</Package>
 		<Package>libnettle-32bit-devel</Package>
 		<Package>chrome-gnome-shell</Package>
+		<Package>gtest-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2849,5 +2849,8 @@
 		<!-- for the relevant browser -->
 		<!-- Replaced by gnome-browser-extension upstream -->
 		<Package>chrome-gnome-shell</Package>
+
+		<!-- Disabled libsplit for gtest -->
+		<Package>gtest-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
Disabled libsplit for gtest so there is no longer a -devel package.

## Does this request depend on package changes to land first?
No
