### PR TITLE
Deprecate python-backcall and python-jinja2-time

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2203,6 +2203,8 @@
 		<Package>mage</Package>
 		<Package>mage-dbginfo</Package>
 		<Package>python-funcsigs</Package>
+		<Package>python-backcall</Package>
+		<Package>python-jinja2-time</Package>
 		<Package>qt6.5d</Package>
 		<Package>qt6.5d-demos</Package>
 		<Package>qt6.5d-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2802,6 +2802,12 @@
 		<!-- Not needed for py3 python-mock -->
 		<Package>python-funcsigs</Package>
 
+		<!-- Not needed anymore by python3-ipython -->
+		<Package>python-backcall</Package>
+
+		<!-- Not needed anymore by python-cookiecutter -->
+		<Package>python-jinja2-time</Package>
+
 		<!-- Just an unfortunate typo, correct name is qt6-3d -->
 		<Package>qt6.5d</Package>
 		<Package>qt6.5d-demos</Package>


### PR DESCRIPTION
## Reason
Orphan packages. No more needed by their revdeps.

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [ ] NO

## Package PR
https://github.com/getsolus/packages/pull/802
