### PR TITLE
repo_data: deprecate pandoc-citeproc

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2229,5 +2229,6 @@
 		<Package>libnettle-32bit-devel</Package>
 		<Package>chrome-gnome-shell</Package>
 		<Package>gtest-devel</Package>
+		<Package>pandoc-citeproc</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2852,5 +2852,8 @@
 
 		<!-- Disabled libsplit for gtest -->
 		<Package>gtest-devel</Package>
+
+		<!-- Merged into pandoc -->
+		<Package>pandoc-citeproc</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

[`pandoc-citeproc`](https://github.com/jgm/pandoc-citeproc) has been archived and merged into `pandoc` itself, so there's no need in keeping the package.

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [x] Yes

## Package PR
_The URL to the package change this depends on, if any_

getsolus/packages#828
