### PR TITLE
repo_data: Reintroduce python-xxhash for calibre

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1077,8 +1077,6 @@
 		<Package>python-speech-recognition-dbginfo</Package>
 		<Package>python-vlc</Package>
 		<Package>python-xmlrunner</Package>
-		<Package>python-xxhash</Package>
-		<Package>python-xxhash-dbginfo</Package>
 		<Package>libuninameslist</Package>
 		<Package>libuninameslist-dbginfo</Package>
 		<Package>libuninameslist-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1522,8 +1522,6 @@
 		<Package>python-speech-recognition-dbginfo</Package>
 		<Package>python-vlc</Package>
 		<Package>python-xmlrunner</Package>
-		<Package>python-xxhash</Package>
-		<Package>python-xxhash-dbginfo</Package>
 
 		<!-- no longer used or required by fontforge -->
 		<Package>libuninameslist</Package>


### PR DESCRIPTION
## Reason

`python-xxhash` is a new dependency for `calibre`
This request unblock `calibre` update.
