### PR TITLE
repo_data: Deprecate orphan python packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2253,6 +2253,10 @@
 		<Package>mongodb-dbginfo</Package>
 		<Package>python-pymongo</Package>
 		<Package>python-pymongo-dbginfo</Package>
+		<Package>python-jdcal</Package>
+		<Package>python-ndg-httpsclient</Package>
+		<Package>python-texttable</Package>
+		<Package>python3-ezsetup</Package>
 		<Package>libgcrypt11</Package>
 		<Package>libgcrypt11-dbginfo</Package>
 		<Package>libgcrypt11-32bit</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2897,6 +2897,12 @@
 		<Package>python-pymongo</Package>
 		<Package>python-pymongo-dbginfo</Package>
 
+		<!-- Orphan python packages -->
+		<Package>python-jdcal</Package>
+		<Package>python-ndg-httpsclient</Package>
+		<Package>python-texttable</Package>
+		<Package>python3-ezsetup</Package>
+
 		<!-- These are all part of the Steam "scout" runtime which we no longer support -->
 		<Package>libgcrypt11</Package>
 		<Package>libgcrypt11-dbginfo</Package>


### PR DESCRIPTION
## Reason

Orphan python packages
- python-jdcal
- python-ndg-httpsclient
- python-texttable
- python3-ezsetup

## Does this request depend on package changes to land first?

- [x] No

## Package PR
https://github.com/getsolus/packages/pull/1012