### PR TITLE
Repo_data: Deprecate phabricator tools

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2261,5 +2261,7 @@
 		<Package>libgcrypt11-dbginfo</Package>
 		<Package>libgcrypt11-32bit</Package>
 		<Package>libgcrypt11-32bit-dbginfo</Package>
+		<Package>arcanist</Package>
+		<Package>libphutil</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2908,5 +2908,9 @@
 		<Package>libgcrypt11-dbginfo</Package>
 		<Package>libgcrypt11-32bit</Package>
 		<Package>libgcrypt11-32bit-dbginfo</Package>
+
+		<!-- Phabricator tools which we no longer need -->
+		<Package>arcanist</Package>
+		<Package>libphutil</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

- We no longer use phabricator.
- arcanist blocks php updates
- Phabricator is dead upstream.

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [X] Yes

## Package PR
_The URL to the package change this depends on, if any_

getsolus/packages#1162
