### PR TITLE
repo_data: Deprecate perl-locale-maketext

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1316,6 +1316,7 @@
 		<Package>perl-text-charwidth</Package>
 		<Package>perl-text-charwidth-dbginfo</Package>
 		<Package>perl-test-perltidy</Package>
+		<Package>perl-locale-maketext</Package>
 		<Package>budgie-trash-applet</Package>
 		<Package>ldc-devel</Package>
 		<Package>oxygen-sound-theme</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1890,6 +1890,7 @@
 		<Package>perl-text-charwidth</Package>
 		<Package>perl-text-charwidth-dbginfo</Package>
 		<Package>perl-test-perltidy</Package>
+		<Package>perl-locale-maketext</Package>
 
 		<!-- Included in Budgie Desktop now -->
 		<Package>budgie-trash-applet</Package>


### PR DESCRIPTION
## Reason
Not used by anything in the repo


## Does this request depend on package changes to land first?
- [x] Yes

## Package PR
[perl-locale-maketext: Deprecate unused module](https://github.com/getsolus/packages/pull/1283)
