### PR TITLE
repo_data: Deprecate witchblast

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2281,5 +2281,7 @@
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>
 		<Package>onevpl-dbginfo</Package>
+		<Package>witchblast</Package>
+		<Package>witchblast-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2936,5 +2936,9 @@
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>
 		<Package>onevpl-dbginfo</Package>
+
+		<!-- Doesn't support SFML v2.6.* -->
+		<Package>witchblast</Package>
+		<Package>witchblast-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

Package isn't supported after updating SFML to 2.6.*.

## Does this request depend on package changes to land first?

- [ ] Yes

## Package PR
https://github.com/getsolus/packages/pull/1304
