### PR TITLE
repo_data: Deprecate wxsvg

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2281,5 +2281,8 @@
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>
 		<Package>onevpl-dbginfo</Package>
+		<Package>wxsvg</Package>
+		<Package>wxsvg-devel</Package>
+		<Package>wxsvg-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2936,5 +2936,10 @@
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>
 		<Package>onevpl-dbginfo</Package>
+		
+		<!-- Part of failed attempt to include dvdstyler -->
+		<Package>wxsvg</Package>
+		<Package>wxsvg-devel</Package>
+		<Package>wxsvg-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
This package is part of failed attempt to include `dvdstyler` in repo


## Does this request depend on package changes to land first?

- [ ] Yes

## Package PR
https://github.com/getsolus/packages/pull/1390

