### PR TITLE
repo_data: Deprecate coffee

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2281,5 +2281,7 @@
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>
 		<Package>onevpl-dbginfo</Package>
+		<Package>coffee</Package>
+		<Package>coffee-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2936,5 +2936,9 @@
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>
 		<Package>onevpl-dbginfo</Package>
+
+		<!-- Project is unmaintained -->
+		<Package>coffee</Package>
+		<Package>coffee-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

~~Solus staff doesn't deserve this~~ Package is unmaintained since 2019


## Does this request depend on package changes to land first?

- [ ] Yes

## Package PR

https://github.com/getsolus/packages/pull/1391
