### PR TITLE
repo_data: Deprecate pandoc-devel and wireshark-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -913,6 +913,8 @@
 		<Package>cava-devel</Package>
 		<Package>scribus-devel</Package>
 		<Package>vgrep-devel</Package>
+		<Package>pandoc-devel</Package>
+		<Package>wireshark-devel</Package>
 		<Package>libblocksruntime</Package>
 		<Package>libblocksruntime-devel</Package>
 		<Package>qt5-base-docs</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1266,6 +1266,8 @@
 		<Package>cava-devel</Package>
 		<Package>scribus-devel</Package>
 		<Package>vgrep-devel</Package>
+		<Package>pandoc-devel</Package>
+		<Package>wireshark-devel</Package>
 
 		<!-- Replaced by libdispatch -->
 		<Package>libblocksruntime</Package>


### PR DESCRIPTION
## Reason
No more `-devel` from pandoc and wireshark


## Does this request depend on package changes to land first?

- [x] No