### PR TITLE
Remove Skype from Third Party section

### DIFF
--- a/eopkg_assist/backend.py
+++ b/eopkg_assist/backend.py
@@ -69,8 +69,6 @@ APPS = {
         "programming/rubymine/pspec.xml",
     "teamviewer":
         "network/util/teamviewer/pspec.xml",
-    "skype":
-        "network/im/skype/pspec.xml",
     "slack-desktop":
         "network/im/slack-desktop/pspec.xml",
     "spotify":

--- a/solus_sc/thirdparty.py
+++ b/solus_sc/thirdparty.py
@@ -90,11 +90,6 @@ APPS = {
         ('TeamViewer', 'teamviewer',
         'Application for remote control, desktop sharing, online meetings, web conferencing and file transfer between computers',
         'network/util/teamviewer/pspec.xml'),
-    'skype':
-        ('Skype', 'skype',
-         'Skype for Linux Beta - <i>Skype keeps the world talking, for free.'
-         '</i>',
-         'network/im/skype/pspec.xml'),
     'slack-desktop':
         ('Slack', 'slack',
          'Team communication for the 21st century.',


### PR DESCRIPTION
## Description
This removes Skype from the Third Party section

Microsoft no longer provides updated .deb archives and recommends snap instead

See here for details: https://answers.microsoft.com/en-us/skype/forum/all/skype-for-linux-updates/da864865-d9e9-4819-8a5d-8de8934dd312

Corresponding 3rd-party PR: https://github.com/getsolus/3rd-party/pull/76
Corresponding help-center-docs PR: https://github.com/getsolus/help-center-docs/pull/469

## Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built solus-sc and verified that the patch worked (if needed)
