### PR TITLE
repo_data: Undeprecate kwrite

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1204,7 +1204,6 @@
 		<Package>python-idna_ssl</Package>
 		<Package>python-cssutils</Package>
 		<Package>jtreg5</Package>
-		<Package>kwrite</Package>
 		<Package>giblib</Package>
 		<Package>gst-plugins-bad</Package>
 		<Package>gst-plugins-bad-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1737,9 +1737,6 @@
 		<!-- No longer needed by openjdk-11 -->
 		<Package>jtreg5</Package>
 
-		<!-- Merged back into Kate package -->
-		<Package>kwrite</Package>
-
 		<!-- No longer used by only dependency scrot -->
 		<Package>giblib</Package>
 


### PR DESCRIPTION
## Reason

Kwrite has been split into it's own package again to keep appstream reporting happy.

## Does this request depend on package changes to land first?

- [x] Yes

## Package PR

https://github.com/getsolus/packages/commit/21965ac79c3c430f727053cf542e0d8e19a5dbac

accidentally already pushed to main, will bump once this is merged.