### PR TITLE
Deprecate latencytop

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2286,5 +2286,7 @@
 		<Package>wxsvg</Package>
 		<Package>wxsvg-devel</Package>
 		<Package>wxsvg-dbginfo</Package>
+		<Package>latencytop</Package>
+		<Package>latencytop-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2945,5 +2945,9 @@
 		<Package>wxsvg</Package>
 		<Package>wxsvg-devel</Package>
 		<Package>wxsvg-dbginfo</Package>
+
+		<!-- Unmaintained, better alternatives exist -->
+		<Package>latencytop</Package>
+		<Package>latencytop-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
Unmaintained upstream. Has the major disadvantage that building a kernel with it has a per-kernel-task memory penalty even when the user space tooling is not active. Other tools do not have this issue

## Does this request depend on package changes to land first?
- [x] Yes

## Package PR
getsolus/packages#1484