### PR TITLE
Deprecate curl-gnutls debug symbols

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2289,5 +2289,7 @@
 		<Package>wxsvg-dbginfo</Package>
 		<Package>latencytop</Package>
 		<Package>latencytop-dbginfo</Package>
+		<Package>curl-gnutls-dbginfo</Package>
+		<Package>curl-gnutls-32bit-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2952,5 +2952,9 @@
 		<!-- Unmaintained, better alternatives exist -->
 		<Package>latencytop</Package>
 		<Package>latencytop-dbginfo</Package>
+
+		<!-- Merged into curl package -->
+		<Package>curl-gnutls-dbginfo</Package>
+		<Package>curl-gnutls-32bit-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
Now in curl package

## Does this request depend on package changes to land first?
- [x] Yes

## Package PR
https://github.com/getsolus/packages/pull/1506
