### PR TITLE
repo_data: Deprecate python-pep517

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2255,6 +2255,7 @@
 		<Package>python-selenium-dbginfo</Package>
 		<Package>python-selenium-32bit-dbginfo</Package>
 		<Package>python-argh</Package>
+		<Package>python-pep517</Package>
 		<Package>libgcrypt11</Package>
 		<Package>libgcrypt11-dbginfo</Package>
 		<Package>libgcrypt11-32bit</Package>
@@ -2278,6 +2279,7 @@
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>
 		<Package>onevpl-dbginfo</Package>
+		!-- Unmaintained -->
 		<Package>sc-controller</Package>
 		<Package>sc-controller-dbginfo</Package>
 		<Package>witchblast</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2899,6 +2899,9 @@
 		<Package>python-selenium-32bit-dbginfo</Package>
 		<Package>python-argh</Package>
 
+		<!-- Replaced by python-pyproject-hooks -->
+		<Package>python-pep517</Package>
+
 		<!-- These are all part of the Steam "scout" runtime which we no longer support -->
 		<Package>libgcrypt11</Package>
 		<Package>libgcrypt11-dbginfo</Package>


### PR DESCRIPTION
## Reason

Replaced by `python-pyproject-hooks`

## Does this request depend on package changes to land first?

- [x] Yes

## Package PR
https://github.com/getsolus/packages/pull/1507
