### PR TITLE
repo_data: deprecate fsharp

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2289,5 +2289,6 @@
 		<Package>wxsvg-dbginfo</Package>
 		<Package>latencytop</Package>
 		<Package>latencytop-dbginfo</Package>
+		<Package>fsharp</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2952,5 +2952,8 @@
 		<!-- Unmaintained, better alternatives exist -->
 		<Package>latencytop</Package>
 		<Package>latencytop-dbginfo</Package>
+
+		<!-- Included in the .net sdk -->
+		<Package>fsharp</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
It's included in the .net sdk

## Does this request depend on package changes to land first?

- [x] Yes

## Package PR
https://github.com/getsolus/packages/pull/1498