### PR TITLE
repo_data: Deprecate giblib-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -1203,6 +1203,7 @@
 		<Package>jtreg5</Package>
 		<Package>kwrite</Package>
 		<Package>giblib</Package>
+		<Package>giblib-devel</Package>
 		<Package>gst-plugins-bad</Package>
 		<Package>gst-plugins-bad-dbginfo</Package>
 		<Package>gst-plugins-bad-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1737,6 +1737,7 @@
 
 		<!-- No longer used by only dependency scrot -->
 		<Package>giblib</Package>
+		<Package>giblib-devel</Package>
 
 		<!-- No longer build, also they aren't rundeps for anything -->
 		<Package>gst-plugins-bad</Package>


### PR DESCRIPTION
## Reason
giblib was deprecated but the -devel package was overlooked: getsolus/solus-sc#189

This was realised by livingsilver94 when trying to install the programming.devel component resulting in
>**System error. Program terminated.
>giblib release 7 dependency of package giblib-devel is not satisfied**


## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [ ] Yes

## Package PR
_The URL to the package change this depends on, if any_

< PR URL >
