### PR TITLE
Deprecate bash-recovery

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2294,5 +2294,6 @@
 		<Package>fsharp</Package>
 		<Package>curl-gnutls-dbginfo</Package>
 		<Package>curl-gnutls-32bit-dbginfo</Package>
+		<Package>bash-recovery</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2963,5 +2963,8 @@
 		<!-- Merged into curl package -->
 		<Package>curl-gnutls-dbginfo</Package>
 		<Package>curl-gnutls-32bit-dbginfo</Package>
+
+		<!-- No longer used -->
+		<Package>bash-recovery</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
We're not using it anymore

## Does this request depend on package changes to land first?
- [x] Yes

## Package PR
https://github.com/getsolus/packages/pull/1620