### PR TITLE
Deprecate gradio

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2292,5 +2292,6 @@
 		<Package>fsharp</Package>
 		<Package>curl-gnutls-dbginfo</Package>
 		<Package>curl-gnutls-32bit-dbginfo</Package>
+		<Package>gradio</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2959,5 +2959,8 @@
 		<!-- Merged into curl package -->
 		<Package>curl-gnutls-dbginfo</Package>
 		<Package>curl-gnutls-32bit-dbginfo</Package>
+
+		<!-- Replaced by shortwave -->
+		<Package>gradio</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
gradio is replaced by shortwave

## Reason
The maintainer of the gradio project has indicated that the project is unmaintained and the successor is `shortwave`
See https://github.com/getsolus/packages/issues/1456

## Does this request depend on package changes to land first?

- [x] Yes

## Package PR

https://github.com/getsolus/packages/pull/1670
