### PR TITLE
repo_data: Deprecate libwebkit-gtk5

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2275,6 +2275,9 @@
 		<Package>bro</Package>
 		<Package>bro-devel</Package>
 		<Package>bro-dbginfo</Package>
+		<Package>libwebkit-gtk5</Package>
+		<Package>libwebkit-gtk5-devel</Package>
+		<Package>libwebkit-gtk5-dbginfo</Package>
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>
 		<Package>onevpl-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2927,6 +2927,11 @@
 		<Package>bro-devel</Package>
 		<Package>bro-dbginfo</Package>
 
+		<!-- Renamed to libwebkit-gtk6 to match upstream -->
+		<Package>libwebkit-gtk5</Package>
+		<Package>libwebkit-gtk5-devel</Package>
+		<Package>libwebkit-gtk5-dbginfo</Package>
+
 		<!-- Renamed to libvpl -->
 		<Package>onevpl</Package>
 		<Package>onevpl-devel</Package>


### PR DESCRIPTION
## Reason

renamed to libwebkit-gtk6 to match upstream

## Does this request depend on package changes to land first?

- [x] Yes

## Package PR

https://github.com/getsolus/packages/pull/1677
