### PR TITLE
repo_data: Deprecate python-ml_dtypes

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2270,6 +2270,8 @@
 		<Package>phonon-devel</Package>
 		<Package>kdsoap</Package>
 		<Package>kdsoap-devel</Package>
+		<Package>python-ml_dtypes</Package>
+		<Package>python-ml_dtypes-dbginfo</Package>
 		<Package>arcanist</Package>
 		<Package>libphutil</Package>
 		<Package>bro</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2918,6 +2918,10 @@
 		<Package>kdsoap</Package>
 		<Package>kdsoap-devel</Package>
 
+		<!-- Wrong pushed with wrong package name -->
+		<Package>python-ml_dtypes</Package>
+		<Package>python-ml_dtypes-dbginfo</Package>
+
 		<!-- Phabricator tools which we no longer need -->
 		<Package>arcanist</Package>
 		<Package>libphutil</Package>


### PR DESCRIPTION

## Reason
Wrongly pushed with the wrong package name, should have been python-ml-dtypes

## Does this request depend on package changes to land first?

- [ ] Yes

## Package PR

N/A
