### PR TITLE
Deprecate wlroots-11

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2300,5 +2300,8 @@
 		<Package>curl-gnutls-dbginfo</Package>
 		<Package>curl-gnutls-32bit-dbginfo</Package>
 		<Package>bash-recovery</Package>
+		<Package>wlroots-11</Package>
+		<Package>wlroots-11-dbginfo</Package>
+		<Package>wlroots-11-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2977,5 +2977,10 @@
 
 		<!-- No longer used -->
 		<Package>bash-recovery</Package>
+
+		<!-- No longer needed -->
+		<Package>wlroots-11</Package>
+		<Package>wlroots-11-dbginfo</Package>
+		<Package>wlroots-11-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
This was used by Sway as a transition package since it had not yet been updated to support the new wlroots. A new version of sway is out that works with the normal wlroots package, so this is useless.

## Does this request depend on package changes to land first?
No, already landed.