### PR TITLE
repo_data: Deprecate fotoxx

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2306,5 +2306,7 @@
 		<Package>wlroots-11</Package>
 		<Package>wlroots-11-dbginfo</Package>
 		<Package>wlroots-11-devel</Package>
+		<Package>fotoxx</Package>
+		<Package>fotoxx-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2991,5 +2991,9 @@
 		<Package>wlroots-11</Package>
 		<Package>wlroots-11-dbginfo</Package>
 		<Package>wlroots-11-devel</Package>
+
+		<!-- fotoxx has been renamed to fotocx -->
+		<Package>fotoxx</Package>
+		<Package>fotoxx-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

`fotoxx` has been renamed to `fotocx`

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [x] Yes

## Package PR
getsolus/packages/pull/1832

