### PR TITLE
Deprecate lbreakout2

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2347,5 +2347,7 @@
 		<Package>fotoxx-dbginfo</Package>
 		<Package>bustle</Package>
 		<Package>bustle-dbginfo</Package>
+		<Package>lbreakout2</Package>
+		<Package>lbreakout2-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3052,5 +3052,9 @@
 		<!-- No maintainer, flatpak avilable -->
 		<Package>bustle</Package>
 		<Package>bustle-dbginfo</Package>
+		
+		<!-- Unmaintained and Replaced by lbreakouthd -->
+		<Package>lbreakout2</Package>
+		<Package>lbreakout2-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

This package is unmaintained and replaced by lbreakouthd

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [x] Yes

## Package PR
_The URL to the package change this depends on, if any_

https://github.com/getsolus/packages/pull/1844
