### PR TITLE
Deprecate flickcurl-docs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2307,5 +2307,6 @@
 		<Package>wlroots-11-devel</Package>
 		<Package>gradio</Package>
 		<Package>gradio-dbginfo</Package>
+		<Package>flickcurl-docs</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -2994,5 +2994,8 @@
 		<!-- Replaced by shortwave -->
 		<Package>gradio</Package>
 		<Package>gradio-dbginfo</Package>
+
+		<!-- Missed in earlier deprecation -->
+		<Package>flickcurl-docs</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
This should have been deprecated along with the rest of the `flickcurl` packages.

## Does this request depend on package changes to land first?

- No
