### PR TITLE
Deprecate powerlevel9k

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2347,5 +2347,6 @@
 		<Package>fotoxx-dbginfo</Package>
 		<Package>bustle</Package>
 		<Package>bustle-dbginfo</Package>
+		<Package>powerlevel9k</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3049,8 +3049,11 @@
 		<Package>fotoxx</Package>
 		<Package>fotoxx-dbginfo</Package>
 
-		<!-- No maintainer, flatpak avilable -->
+		<!-- No maintainer, flatpak available -->
 		<Package>bustle</Package>
 		<Package>bustle-dbginfo</Package>
+
+		<!-- Dead upstream and replaced by powerlevel10k -->
+		<Package>powerlevel9k</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

The package source has been archived by its maintainer. Powerlevel10k has been added to the repo to take its place.

Resolves getsolus/packages/issues/1933

## Does this request depend on package changes to land first?

- [ ] Yes