### PR TITLE
Deprecate libquvi and libquvi-scripts

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2350,5 +2350,7 @@
 		<Package>powerlevel9k</Package>
 		<Package>lbreakout2</Package>
 		<Package>lbreakout2-dbginfo</Package>
+        <Package>libquvi</Package>
+        <Package>libquvi-scripts</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3059,5 +3059,8 @@
 		<!-- Unmaintained and Replaced by lbreakouthd -->
 		<Package>lbreakout2</Package>
 		<Package>lbreakout2-dbginfo</Package>
+        <!-- Obsolete and dead upstream -->
+        <Package>libquvi</Package>
+        <Package>libquvi-scripts</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

They have not been updated since 2013 and no longer build. They are used for parsing flash media files, which have been long deprecated. Nothing is using these.

## Does this request depend on package changes to land first?

- [ ] Yes

Resolves getsolus/packages/issues/1818