### PR TITLE
Deprecate evopop-icon-theme

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2356,5 +2356,6 @@
 		<Package>openastro-data</Package>
 		<Package>pyswisseph</Package>
 		<Package>pyswisseph-dbginfo</Package>
+		<Package>evopop-icon-theme</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3071,5 +3071,8 @@
 		<!-- Dependency of openastro, now removed -->
 		<Package>pyswisseph</Package>
 		<Package>pyswisseph-dbginfo</Package>
+
+		<!-- Unmaintained since 2017 -->
+		<Package>evopop-icon-theme</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

Old Solus project, unmaintained since 2017
Resolves #317 

## Does this request depend on package changes to land first?

- [x] Yes

## Package PR

https://github.com/getsolus/packages/pull/2153
