### PR TITLE
distribution: Deprecate Yuzu

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2356,5 +2356,8 @@
 		<Package>openastro-data</Package>
 		<Package>pyswisseph</Package>
 		<Package>pyswisseph-dbginfo</Package>
+		<Package>yuzu</Package>
+		<Package>yuzu-dbginfo</Package>
+		<Package>yuzu-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3071,5 +3071,10 @@
 		<!-- Dependency of openastro, now removed -->
 		<Package>pyswisseph</Package>
 		<Package>pyswisseph-dbginfo</Package>
+
+		<!-- Ninendo doesn't want this to exist, and we don't want the liability -->
+		<Package>yuzu</Package>
+		<Package>yuzu-dbginfo</Package>
+		<Package>yuzu-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

Nintendo has been sending out takedown requests to places serving Yuzu code and/or packages. The Solus team doesn't want the liability, so we have decided to remove it from our repository.

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [ ] Yes

## Package PR
_The URL to the package change this depends on, if any_

n/a
