### PR TITLE
Deprecate font-symbola-ttf

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2377,5 +2377,6 @@
 		<Package>pkg-config</Package>
 		<Package>pkg-config-dbginfo</Package>
 		<Package>cups-docs</Package>
+		<Package>font-symbola-ttf</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3116,5 +3116,8 @@
 
 		<!-- Merged back into cups (these were actually the webui files) -->
 		<Package>cups-docs</Package>
+
+		<!-- Source unavailable, license change -->
+		<Package>font-symbola-ttf</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Reasoning: https://github.com/getsolus/packages/issues/2494

## Reason

- Original source now 404s: http://users.teilar.gr/~g1951d/Symbola.zip
- Author has all font work to https://dn-works.com/ufas/
- Font only distributed by pdf now
- Subject to non-free custom license: https://dn-works.com/wp-content/uploads/2023/UFAS010223/License.pdf

## Does this request depend on package changes to land first?

*No*

## Package PR

https://github.com/getsolus/packages/pull/2495
