### PR TITLE
Deprecate gnome-system-tools

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3116,5 +3116,10 @@
 
 		<!-- Merged back into cups (these were actually the webui files) -->
 		<Package>cups-docs</Package>
+
+		<!-- No updates since 2011 -->
+		<Package>gnome-system-tools</Package>
+		<Package>gnome-system-tools-dbginfo</Package>
+		<Package>gnome-system-tools-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

No updates since 2011. Refer to
https://github.com/getsolus/packages/issues/2390

## Does this request depend on package changes to land first?

*No*

## Package PR

Related to https://github.com/getsolus/packages/pull/2497
