### PR TITLE
repo_data: Deprecate pdf2djvu

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2383,6 +2383,9 @@
 		<Package>gnome-system-tools</Package>
 		<Package>gnome-system-tools-dbginfo</Package>
 		<Package>gnome-system-tools-devel</Package>
+		<Package>pdf2djvu</Package>
+		<Package>pdf2djvu-dbginfo</Package>
+		<Package>pdf2djvu-devel</Package>
 		<Package>flow-pomodoro</Package>
 		<Package>flow-pomodoro-dbginfo</Package>
 		<Package>font-symbola-ttf</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3127,6 +3127,11 @@
 		<Package>gnome-system-tools-dbginfo</Package>
 		<Package>gnome-system-tools-devel</Package>
 
+		<!-- Dead upstream Jan '24, doesn't build against poppler -->
+		<Package>pdf2djvu</Package>
+		<Package>pdf2djvu-dbginfo</Package>
+		<Package>pdf2djvu-devel</Package>
+
 		<!-- No upstream releases since 2017 -->
 		<Package>flow-pomodoro</Package>
 		<Package>flow-pomodoro-dbginfo</Package>


### PR DESCRIPTION
## Reason

Archived upstream Jan '24. Doesn't build against new poppler releases.

## Does this request depend on package changes to land first?

- [] Yes

## Package PR

N/A

## ISO check

- [x] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
