### PR TITLE
Deprecate cni-plugins and slirp4netns

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2389,5 +2389,7 @@
 		<Package>flow-pomodoro</Package>
 		<Package>flow-pomodoro-dbginfo</Package>
 		<Package>font-symbola-ttf</Package>
+		<Package>cni-plugins</Package>
+		<Package>slirp4netns</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3138,5 +3138,9 @@
 
 		<!-- Source unavailable, license change -->
 		<Package>font-symbola-ttf</Package>
+
+		<!-- cni-plugins replaced by netavark, slirp4netns replaced by passt -->
+		<Package>cni-plugins</Package>
+		<Package>slirp4netns</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

Package cni-plugins is replaced by package netavark.
Package slirp4netns is replaced by passt.

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [x] Yes

## Package PR
_The URL to the package change this depends on, if any_

getsolus/packages#2592

## ISO check
_Is this package part of the ISOs? Check common/iso_packages.txt_ and iso-tooling repository (private).

- [x] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
