### PR TITLE
Deprecation: wxwidgets30, Let's drop this like a sack of potatoes.

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -51,6 +51,9 @@
 		<Package>pcre</Package>
 		<Package>pcre-devel</Package>
 		<Package>webkitgtk</Package>
+		<Package>wxwidgets30</Package>
+		<Package>wxwidgets30-devel</Package>
+		<Package>wxwidgets30-dbginfo</Package>
 		<Package>gnome-icon-theme-symbolic-devel</Package>
 		<Package>cairo</Package>
 		<Package>cairo-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -14,6 +14,11 @@
 		<!-- Replaced by libwebkit-gtk -->
 		<Package>webkitgtk</Package>
 
+		<!-- No longer needed for freefilesync -->
+		<Package>wxwidgets30</Package>
+		<Package>wxwidgets30-devel</Package>
+		<Package>wxwidgets30-dbginfo</Package>
+
 		<Package>gnome-icon-theme-symbolic-devel</Package>
 
 		<!-- Replaced by cairo -->


### PR DESCRIPTION


## Reason
_Reason for deprecation or undeprecation_

This is no longer needed now that FreeFileSync can now compile against WxWidgets 3.2 GTK3

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [*] Yes

## Package PR
_The URL to the package change this depends on, if any_

[< PR URL >](https://github.com/getsolus/packages/pull/757)

## ISO check
_Is this package part of the ISOs? Check common/iso_packages.txt_ and iso-tooling repository (private).

- [*] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
