### PR TITLE
Deprecate qomui

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2396,5 +2396,6 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+		<Package>qomui</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3149,5 +3149,8 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+
+		<!-- Upstream dead for 5+ years, doesn't run -->
+		<Package>qomui</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

Upstream dead for 5+ years, does not run

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- *No*

## Package PR

Related: https://github.com/getsolus/packages/pull/2711

## ISO check
_Is this package part of the ISOs? Check common/iso_packages.txt_ and iso-tooling repository (private).

- [x] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
