### PR TITLE
Deprecate lollypop-portal

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2396,5 +2396,6 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+		<Package>lollypop-portal</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3149,5 +3149,8 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+
+		<!-- No release in 6 years, archived-->
+		<Package>lollypop-portal</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

- No release for 6 years, upstream archived
- Used for basic tagging by lollypop, does not appear to be supported anymore

## Does this request depend on package changes to land first?

- *No*

## Package PR

Related https://github.com/getsolus/packages/pull/2712

## ISO check
_Is this package part of the ISOs? Check common/iso_packages.txt_ and iso-tooling repository (private).

- [x] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
