### PR TITLE
Deprecate dep

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2396,5 +2396,7 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+		<Package>dep</Package>
+		<Package>dep-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3149,5 +3149,9 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+
+		<!-- Go dependency manager, superceded by Go modules -->
+		<Package>dep</Package>
+		<Package>dep-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason

- Go dependency manager, superseded by official Go module support

## Does this request depend on package changes to land first?

- *No*

## Package PR

https://github.com/getsolus/packages/pull/2713

## ISO check
_Is this package part of the ISOs? Check common/iso_packages.txt_ and iso-tooling repository (private).

- [x] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
