### PR TITLE
Deprecate libbaseencode

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2396,5 +2396,9 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+		<Package/>
+		<Package>libbaseencode</Package>
+		<Package>libbaseencode-devel</Package>
+		<Package>libbaseencode-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3149,5 +3149,11 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+
+		<!-- It was a dependency of otpclient but dropped in favor of libcotp and also been archived upstream -->
+		<Package></Package>
+		<Package>libbaseencode</Package>
+		<Package>libbaseencode-devel</Package>
+		<Package>libbaseencode-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

It was a dependency of otpclient but dropped in favor of libcotp and also been archived upstream. 

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [x] Yes

## Package PR
_The URL to the package change this depends on, if any_

https://github.com/getsolus/packages/pull/2750

## ISO check
_Is this package part of the ISOs? Check common/iso_packages.txt_ and iso-tooling repository (private).

- [ ] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
