### PR TITLE
Deprecate libdnet

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2396,5 +2396,7 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+		<Package>libdnet</Package>
+		<Package>libdnet-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3149,5 +3149,9 @@
 		<Package>cni-plugins-dbginfo</Package>
 		<Package>slirp4netns</Package>
 		<Package>slirp4netns-dbginfo</Package>
+
+		<!-- No longer needed in repository -->
+		<Package>libdnet</Package>
+		<Package>libdnet-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_

it is not needed by any package in repository

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [x] Yes

## Package PR
_The URL to the package change this depends on, if any_

https://github.com/getsolus/packages/pull/2775

## ISO check
_Is this package part of the ISOs? Check common/iso_packages.txt_ and iso-tooling repository (private).

- [ ] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
