### PR TITLE
Deprecate redkite

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2411,5 +2411,8 @@
 		<Package>dep-dbginfo</Package>
 		<Package>libdnet</Package>
 		<Package>libdnet-devel</Package>
+		<Package>redkite</Package>
+		<Package>redkite-devel</Package>
+		<Package>redkite-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3176,5 +3176,10 @@
 		<!-- No longer needed in repository -->
 		<Package>libdnet</Package>
 		<Package>libdnet-devel</Package>
+
+        <!-- No longer developed as a standalone library; its code has become a part of the Geonkick codebase -->
+		<Package>redkite</Package>
+		<Package>redkite-devel</Package>
+		<Package>redkite-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
## Reason
_Reason for deprecation or undeprecation_
No longer developed as a standalone library; its code has become a part of the Geonkick codebase

## Does this request depend on package changes to land first?
_This request depends on a package change to land before this can be merged._

- [x] Yes

## Package PR
_The URL to the package change this depends on, if any_
https://github.com/getsolus/packages/pull/2860

## ISO check
_Is this package part of the ISOs? Check common/iso_packages.txt_ and iso-tooling repository (private).

- [ ] This package is not part of the ISOs OR There is a PR to remove it from the ISOs
